### PR TITLE
Update coordinator.py

### DIFF
--- a/custom_components/bmw_wallbox/coordinator.py
+++ b/custom_components/bmw_wallbox/coordinator.py
@@ -433,15 +433,17 @@ class WallboxChargePoint(cp):
         """Handle SecurityEventNotification - wallbox security events like time sync."""
         _LOGGER.debug("Security Event: type=%s, timestamp=%s", type, timestamp)
         return call_result.SecurityEventNotification()
-    
+
     @on("NotifyEvent")
     async def on_notify_event(self, **kwargs):
         """Handle NotifyEvent (OCPP 2.0.1).
+
         Some chargers send this frequently. We accept it to avoid repeated
         NotImplementedError / KeyError that can overload HA logs and event loop.
         """
-        _LOGGER.debug("📩 NotifyEvent received: %s", kwargs)
+        _LOGGER.debug("NotifyEvent received: %s", kwargs)
         return call_result.NotifyEvent()
+
 
 class BMWWallboxCoordinator(DataUpdateCoordinator):
     """Class to manage fetching BMW Wallbox data."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -304,6 +304,31 @@ async def test_security_event_notification_handler(charge_point):
     assert response is not None
 
 
+async def test_notify_event_handler(charge_point):
+    """Test NotifyEvent handler.
+
+    Some wallboxes send NotifyEvent frequently. The handler accepts it
+    to prevent NotImplementedError spam in logs.
+    """
+    response = await charge_point.on_notify_event(
+        generated_at=datetime.utcnow().isoformat(),
+        seq_no=1,
+        event_data=[
+            {
+                "event_id": 1,
+                "timestamp": datetime.utcnow().isoformat(),
+                "trigger": "Alerting",
+                "actual_value": "true",
+                "component": {"name": "Connector", "evse": {"id": 1}},
+                "variable": {"name": "Available"},
+            }
+        ],
+    )
+
+    # Should not raise exception
+    assert response is not None
+
+
 # ==============================================================================
 # COMMAND TESTS
 # ==============================================================================


### PR DESCRIPTION
Add a handler for OCPP 2.0.1 NotifyEvent.

Some wallboxes send this message frequently. Without a handler, the OCPP library raises repeated NotImplementedError exceptions, causing log spam and Home Assistant instability.

This change accepts NotifyEvent and returns a valid response, preventing error loops and improving system stability.