### PR TITLE
fix: support NotifyEVChargingNeeds (#14) and current-limit timing/stale Current sensor (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2026-06-20
+
+### Added
+
+- **`NotifyEVChargingNeeds` handler (OCPP 2.0.1 / ISO 15118)** - Wallboxes that perform high-level EV charging-needs negotiation (e.g. BMW Wallbox Plus Gen 4 / Delta) send `NotifyEVChargingNeeds`. Without a handler the OCPP library replied with a `CallError` and flooded the log. The message is now acknowledged cleanly, keeping the OCPP session healthy ([#14](https://github.com/JoaoPedroBelo/bmw-wallbox-ha/issues/14))
+- **`TxDefaultProfile` for the charging current limit** - A default charging profile is now installed when the wallbox connects and on every limit change, and the limit is pushed immediately when a transaction starts. This stops the wallbox from charging at full power for up to ~2 minutes at the start of a session before the configured limit is applied ([#15](https://github.com/JoaoPedroBelo/bmw-wallbox-ha/issues/15))
+
+### Fixed
+
+- **`Current` sensor stuck at the last value** - The live current was only recomputed when missing, so it stayed frozen while power changed and after a session ended. It is now recomputed on every meter update (priority: per-phase → power/voltage → reported total) and reset when the session ends. The Delta firmware freezes its non-phased total register while the per-phase readings track reality, so per-phase now takes precedence ([#15](https://github.com/JoaoPedroBelo/bmw-wallbox-ha/issues/15))
+
+### Changed
+
+- The charging current limit can now be set without an active charging session (a `TxDefaultProfile` is applied so it takes effect on the next session)
+
 ## [1.6.3] - 2026-04-26
 
 ### Changed

--- a/custom_components/bmw_wallbox/coordinator.py
+++ b/custom_components/bmw_wallbox/coordinator.py
@@ -32,6 +32,7 @@ from ocpp.v201.enums import (
     ChargingProfilePurposeEnumType,
     ChargingRateUnitEnumType,
     IdTokenEnumType,
+    NotifyEVChargingNeedsStatusEnumType,
     RegistrationStatusEnumType,
     RequestStartStopStatusEnumType,
     ResetEnumType,
@@ -48,6 +49,49 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _compute_live_current(
+    data: dict[str, Any],
+    reported_total: float | None,
+    power: float | None,
+    voltage: float | None,
+    phases: int,
+) -> float | None:
+    """Best-effort live charging current in amps, recomputed every meter update.
+
+    Recomputed on every MeterValues/TransactionEvent so the sensor never sticks
+    at a stale value once power or phase currents change (issue #15).
+
+    Order of preference, by observed reliability on the BMW/Delta firmware:
+    1. the average of the active per-phase currents (these update correctly),
+    2. a value derived from power and voltage (always fresh while charging),
+    3. a directly reported non-phased Current.Import - LAST resort, because this
+       firmware leaves that total register frozen at the pre-limit value while
+       the per-phase readings track reality.
+    Returns None when nothing usable is available.
+    """
+    active = [
+        x
+        for x in (
+            data.get("current_l1") or 0,
+            data.get("current_l2") or 0,
+            data.get("current_l3") or 0,
+        )
+        if x > 0
+    ]
+    if active:
+        return round(sum(active) / len(active), 1)
+
+    if power and power > 0 and voltage and voltage > 0:
+        if phases == 3:
+            return round(power / (voltage * 1.732), 1)  # sqrt(3) ≈ 1.732
+        return round(power / voltage, 1)
+
+    if reported_total is not None:
+        return round(reported_total, 1)
+
+    return None
 
 
 class WallboxChargePoint(cp):
@@ -107,6 +151,7 @@ class WallboxChargePoint(cp):
         """Handle MeterValues from wallbox (triggered or periodic)."""
         _LOGGER.info("📊 MeterValues received for EVSE %s", evse_id)
 
+        reported_total_current = None  # non-phased Current.Import seen this event
         for mv in meter_value:
             timestamp = mv.get("timestamp")
             _LOGGER.debug("  Timestamp: %s", timestamp)
@@ -145,14 +190,14 @@ class WallboxChargePoint(cp):
                             current_energy,
                         )
                 elif measurand == "Current.Import":
-                    if phase == "L1-N":
+                    if phase in ("L1", "L1-N"):
                         self.coordinator.data["current_l1"] = float(value)
-                    elif phase == "L2-N":
+                    elif phase in ("L2", "L2-N"):
                         self.coordinator.data["current_l2"] = float(value)
-                    elif phase == "L3-N":
+                    elif phase in ("L3", "L3-N"):
                         self.coordinator.data["current_l3"] = float(value)
                     else:
-                        self.coordinator.data["current"] = float(value)
+                        reported_total_current = float(value)
                 elif measurand == "Voltage":
                     if phase == "L1-N":
                         self.coordinator.data["voltage_l1"] = float(value)
@@ -162,6 +207,16 @@ class WallboxChargePoint(cp):
                         self.coordinator.data["voltage_l3"] = float(value)
                     else:
                         self.coordinator.data["voltage"] = float(value)
+
+        # Recompute the live current so the sensor never sticks (issue #15)
+        self.coordinator.data["current"] = _compute_live_current(
+            self.coordinator.data,
+            reported_total_current,
+            self.coordinator.data.get("power") or 0,
+            self.coordinator.data.get("voltage") or 0,
+            self.coordinator.data.get("phases_used", 1) or 1,
+        )
+
         self.coordinator.async_set_updated_data(self.coordinator.data)
         return call_result.MeterValues()
 
@@ -199,6 +254,13 @@ class WallboxChargePoint(cp):
         self.current_transaction_id = transaction_info.get("transaction_id")
         self.coordinator.current_transaction_id = self.current_transaction_id
 
+        # On a fresh session start, push the configured limit immediately so the
+        # wallbox doesn't run at full power until the next poll (issue #15).
+        if event_type == "Started":
+            asyncio.create_task(
+                self.coordinator.async_apply_limit_on_transaction_start()
+            )
+
         # Update coordinator data with basic transaction info
         self.coordinator.data.update(
             {
@@ -219,6 +281,7 @@ class WallboxChargePoint(cp):
             self.coordinator.data["id_token_type"] = id_token.get("type")
 
         # Extract meter values if present
+        reported_total_current = None  # non-phased Current.Import seen this event
         meter_value = kwargs.get("meter_value", [])
         if meter_value:
             _LOGGER.info("📊 Processing %d meter value(s)", len(meter_value))
@@ -303,8 +366,8 @@ class WallboxChargePoint(cp):
                         elif phase == "L3":
                             self.coordinator.data["current_l3"] = current_value
                         else:
-                            # Total or unspecified - store as main current
-                            self.coordinator.data["current"] = current_value
+                            # Total or unspecified - prefer this as the live current
+                            reported_total_current = current_value
 
                         _LOGGER.debug("Current: value=%s, phase=%s", value, phase)
 
@@ -361,46 +424,13 @@ class WallboxChargePoint(cp):
                     self.coordinator.data["voltage"] = voltage
                     _LOGGER.debug("Calculated voltage from phases: %.0fV", voltage)
 
-        # Calculate total current from per-phase if main current is missing
-        if (
-            self.coordinator.data["current"] == 0
-            or self.coordinator.data["current"] is None
-        ):
-            l1 = self.coordinator.data.get("current_l1", 0) or 0
-            l2 = self.coordinator.data.get("current_l2", 0) or 0
-            l3 = self.coordinator.data.get("current_l3", 0) or 0
-            if l1 or l2 or l3:
-                # Use average of active phases
-                active = [x for x in [l1, l2, l3] if x > 0]
-                if active:
-                    self.coordinator.data["current"] = sum(active) / len(active)
-                    _LOGGER.debug(
-                        "Calculated current from phases: %.1fA",
-                        self.coordinator.data["current"],
-                    )
-
-        # Calculate current from power and voltage if still missing
-        if (
-            (
-                self.coordinator.data["current"] == 0
-                or self.coordinator.data["current"] is None
-            )
-            and power > 0
-            and voltage > 0
-        ):
-            # I = P / (V * phases * sqrt(3) for 3-phase, or V for 1-phase)
-            if phases == 3:
-                calculated_current = power / (voltage * 1.732)  # sqrt(3) ≈ 1.732
-            else:
-                calculated_current = power / voltage
-            self.coordinator.data["current"] = round(calculated_current, 1)
-            _LOGGER.info(
-                "✓ Calculated current: %.1fA (from P=%dW, V=%.0fV, %d-phase)",
-                calculated_current,
-                power,
-                voltage,
-                phases,
-            )
+        # === Live charging current (issue #15) ===
+        # Recompute on every event so the sensor never sticks at a stale value
+        # once power/phase currents change. Priority: directly reported total →
+        # per-phase average → derived from power/voltage.
+        self.coordinator.data["current"] = _compute_live_current(
+            self.coordinator.data, reported_total_current, power, voltage, phases
+        )
 
         # Smart connector status - derive from charging state if not explicitly set
         if self.coordinator.data.get("connector_status") == "Unknown":
@@ -416,6 +446,12 @@ class WallboxChargePoint(cp):
                 self.coordinator.data["connector_status"] = "Available"
             elif charging_state == "Faulted":
                 self.coordinator.data["connector_status"] = "Faulted"
+
+        # Session ended — clear live readings so the sensors don't stay frozen at
+        # the last value once charging stops (issue #15).
+        if event_type == "Ended":
+            for key in ("current", "power", "current_l1", "current_l2", "current_l3"):
+                self.coordinator.data[key] = 0
 
         # Trigger update
         self.coordinator.async_set_updated_data(self.coordinator.data)
@@ -445,6 +481,21 @@ class WallboxChargePoint(cp):
         """
         _LOGGER.debug("NotifyEvent received: %s", kwargs)
         return call_result.NotifyEvent()
+
+    @on("NotifyEVChargingNeeds")
+    async def on_notify_ev_charging_needs(self, **kwargs):
+        """Handle NotifyEVChargingNeeds (OCPP 2.0.1 / ISO 15118).
+
+        BMW Wallbox Plus Gen 4 (Delta) firmware sends this during the EV
+        charging negotiation. Without a registered handler the ocpp library
+        replies with a CallError (NotImplementedError) and floods the HA log.
+        Acknowledging it cleanly (Accepted) stops the error spam and keeps the
+        OCPP session healthy. Same approach as NotifyEvent. See issue #14.
+        """
+        _LOGGER.debug("NotifyEVChargingNeeds received: %s", kwargs)
+        return call_result.NotifyEVChargingNeeds(
+            status=NotifyEVChargingNeedsStatusEnumType.accepted
+        )
 
 
 class BMWWallboxCoordinator(DataUpdateCoordinator):
@@ -607,6 +658,9 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
 
             # Recover transaction state (id_token, transaction_id) after HA restart
             asyncio.create_task(self._recover_transaction_on_connect())
+
+            # Install TxDefaultProfile so the first session starts at the limit
+            asyncio.create_task(self._apply_default_limit_on_connect())
 
             try:
                 await self.charge_point.start()
@@ -1386,89 +1440,122 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
         _LOGGER.info("⏹️ STOP CHARGING - SetChargingProfile(0A)")
         return await self.async_pause_charging(allow_nuke=allow_nuke)
 
+    async def _send_charging_profile(
+        self,
+        limit: float,
+        *,
+        purpose: ChargingProfilePurposeEnumType,
+        profile_id: int,
+        stack_level: int,
+        transaction_id: str | None = None,
+    ) -> bool:
+        """Build and send a SetChargingProfile, returning True if accepted.
+
+        Shared by the TxDefaultProfile (applies from the start of every session,
+        no transaction needed) and TxProfile (active session) code paths.
+        """
+        start_time = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        schedule = ChargingScheduleType(
+            id=1,
+            start_schedule=start_time,
+            charging_rate_unit=ChargingRateUnitEnumType.amps,
+            charging_schedule_period=[
+                ChargingSchedulePeriodType(start_period=0, limit=float(limit))
+            ],
+        )
+
+        profile_kwargs: dict[str, Any] = {}
+        if transaction_id is not None:
+            profile_kwargs["transaction_id"] = transaction_id
+
+        profile = ChargingProfileType(
+            id=profile_id,
+            stack_level=stack_level,
+            charging_profile_purpose=purpose,
+            charging_profile_kind=ChargingProfileKindEnumType.absolute,
+            charging_schedule=[schedule],
+            **profile_kwargs,
+        )
+
+        _LOGGER.debug(
+            "Sending SetChargingProfile: evse=1, id=%s, purpose=%s, tx=%s, limit=%sA",
+            profile_id,
+            purpose,
+            transaction_id,
+            limit,
+        )
+
+        response = await asyncio.wait_for(
+            self.charge_point.call(
+                call.SetChargingProfile(evse_id=1, charging_profile=profile)
+            ),
+            timeout=15.0,
+        )
+
+        status_str = str(response.status)
+        accepted = status_str == "Accepted" or "accepted" in status_str.lower()
+        if accepted:
+            _LOGGER.info("✅ %s set to %sA - accepted by wallbox", purpose, limit)
+        else:
+            _LOGGER.warning(
+                "⚠️ %s (%sA) rejected by wallbox: %s", purpose, limit, response.status
+            )
+        return accepted
+
     async def async_set_current_limit(self, limit: float) -> bool:
         """Set charging current limit via SetChargingProfile.
 
-        IMPORTANT: This only works during an active charging session!
-        The BMW wallbox requires a transaction_id for tx_profile to work.
+        Sends a TxDefaultProfile so the limit also applies from the very start of
+        the next session (fixes the cold-start overshoot, issue #15), plus a
+        TxProfile bound to the active transaction so it takes effect immediately
+        on the current session.
 
         Args:
-            limit: Current limit in Amps (0 = pause, max = full speed)
+            limit: Current limit in Amps (max = full speed)
 
         Returns:
-            True if command was accepted, False otherwise
+            True if at least one profile was accepted, False otherwise
         """
         if not self.charge_point:
             _LOGGER.error("❌ No wallbox connected - cannot set current limit")
             return False
 
-        if not self.current_transaction_id:
-            _LOGGER.error(
-                "❌ No active transaction - current limit requires an active charging session! "
-                "Start charging first, then you can adjust the current limit."
-            )
-            return False
-
         _LOGGER.info(
-            "⚡ Setting current limit to %sA for transaction %s",
+            "⚡ Setting current limit to %sA (tx=%s)",
             limit,
             self.current_transaction_id,
         )
 
         try:
-            start_time = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-
-            schedule = ChargingScheduleType(
-                id=1,
-                start_schedule=start_time,
-                charging_rate_unit=ChargingRateUnitEnumType.amps,
-                charging_schedule_period=[
-                    ChargingSchedulePeriodType(start_period=0, limit=float(limit))
-                ],
-            )
-
-            # Always use tx_profile with the active transaction
-            profile = ChargingProfileType(
-                id=999,
-                stack_level=1,
-                charging_profile_purpose=ChargingProfilePurposeEnumType.tx_profile,
-                charging_profile_kind=ChargingProfileKindEnumType.absolute,
-                charging_schedule=[schedule],
-                transaction_id=self.current_transaction_id,
-            )
-
-            _LOGGER.debug(
-                "Sending SetChargingProfile: evse=1, profile_id=999, tx=%s, limit=%sA",
-                self.current_transaction_id,
+            # TxDefaultProfile persists across sessions and applies from the start
+            # of the next transaction - prevents the startup overshoot.
+            ok_default = await self._send_charging_profile(
                 limit,
+                purpose=ChargingProfilePurposeEnumType.tx_default_profile,
+                profile_id=998,
+                stack_level=0,
             )
 
-            response = await asyncio.wait_for(
-                self.charge_point.call(
-                    call.SetChargingProfile(evse_id=1, charging_profile=profile)
-                ),
-                timeout=15.0,
-            )
+            # TxProfile takes effect immediately on the running session.
+            ok_tx = False
+            if self.current_transaction_id:
+                ok_tx = await self._send_charging_profile(
+                    limit,
+                    purpose=ChargingProfilePurposeEnumType.tx_profile,
+                    profile_id=999,
+                    stack_level=1,
+                    transaction_id=self.current_transaction_id,
+                )
 
-            # Log the full response for debugging
-            _LOGGER.info(
-                "SetChargingProfile response: status=%s (type=%s)",
-                response.status,
-                type(response.status).__name__,
-            )
-
-            # Handle both string and enum status
-            status_str = str(response.status)
-            if status_str == "Accepted" or "accepted" in status_str.lower():
-                _LOGGER.info("✅ Current limit set to %sA - accepted by wallbox", limit)
-                # Track the new limit for future start/resume operations
+            if ok_default or ok_tx:
+                # Track the new limit for future start/resume/connect operations
                 self.data["current_limit"] = limit
                 self.async_set_updated_data(self.data)
                 return True
+
             _LOGGER.warning(
-                "⚠️ Current limit rejected by wallbox: %s. "
-                "This can happen if the car is not drawing power or the session ended.",
-                response.status,
+                "⚠️ Current limit %sA not applied (no profile accepted)", limit
             )
             return False
 
@@ -1478,6 +1565,42 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
         except Exception as err:
             _LOGGER.error("❌ Failed to set current limit: %s", err, exc_info=True)
             return False
+
+    async def async_apply_limit_on_transaction_start(self) -> None:
+        """Push the configured limit right when a session starts (issue #15).
+
+        Without this the wallbox charges at full power until the next poll picks
+        up the transaction, which can trip the supplier's main breaker.
+        """
+        limit = self.data.get("current_limit")
+        if not limit:
+            return
+        _LOGGER.info("🚀 Transaction started - applying %sA immediately", limit)
+        await self.async_set_current_limit(limit)
+
+    async def _apply_default_limit_on_connect(self) -> None:
+        """Install the TxDefaultProfile after the wallbox connects (issue #15).
+
+        Ensures the very first session after a (re)connect already starts at the
+        configured limit instead of full power.
+        """
+        # Let the connection settle and the pause/resume config run first.
+        await asyncio.sleep(5)
+        if not self.charge_point:
+            return
+        limit = self.data.get("current_limit")
+        if not limit:
+            return
+        try:
+            await self._send_charging_profile(
+                limit,
+                purpose=ChargingProfilePurposeEnumType.tx_default_profile,
+                profile_id=998,
+                stack_level=0,
+            )
+        except Exception as err:
+            # Best-effort - never let this block the connection handler.
+            _LOGGER.warning("Could not install TxDefaultProfile on connect: %s", err)
 
     async def async_trigger_meter_values(self) -> bool:
         """Trigger wallbox to send meter values immediately.

--- a/custom_components/bmw_wallbox/manifest.json
+++ b/custom_components/bmw_wallbox/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "ocpp>=0.20.0"
   ],
-  "version": "1.6.3"
+  "version": "1.7.0"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3,11 +3,13 @@
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from ocpp.v201.enums import ChargingProfilePurposeEnumType
 import pytest
 
 from custom_components.bmw_wallbox.coordinator import (
     BMWWallboxCoordinator,
     WallboxChargePoint,
+    _compute_live_current,
 )
 
 
@@ -327,6 +329,32 @@ async def test_notify_event_handler(charge_point):
 
     # Should not raise exception
     assert response is not None
+
+
+async def test_notify_ev_charging_needs_handler(charge_point):
+    """Test NotifyEVChargingNeeds handler (issue #14).
+
+    BMW Wallbox Plus Gen 4 (Delta) sends NotifyEVChargingNeeds during the EV
+    charging negotiation. The handler must accept it; otherwise the ocpp library
+    raises NotImplementedError, breaking the message pump and stopping
+    SetChargingProfile from being applied.
+    """
+    response = await charge_point.on_notify_ev_charging_needs(
+        evse_id=1,
+        charging_needs={
+            "requested_energy_transfer": "AC_single_phase",
+            "ac_charging_parameters": {
+                "energy_amount": 10000,
+                "ev_min_current": 6,
+                "ev_max_current": 16,
+                "ev_max_voltage": 230,
+            },
+        },
+    )
+
+    # Should not raise exception and must return an Accepted status
+    assert response is not None
+    assert response.status == "Accepted"
 
 
 # ==============================================================================
@@ -736,3 +764,175 @@ async def test_trigger_meter_values_error(coordinator):
     result = await coordinator.async_trigger_meter_values()
 
     assert result is False
+
+
+# ==============================================================================
+# LIVE CURRENT CALCULATION TESTS (issue #15 - stale Current sensor)
+# ==============================================================================
+
+
+def test_compute_live_current_direct_total_last_resort():
+    """A directly reported total is used only when nothing else is available."""
+    assert _compute_live_current({}, 14.0, 0, 0, 1) == 14.0
+
+
+def test_compute_live_current_phase_beats_stale_total():
+    """Per-phase reading wins over a stale non-phased total (issue #15).
+
+    The Delta firmware keeps reporting a frozen non-phased Current.Import (e.g.
+    30.4 from before the limit was applied) while the per-phase reading tracks
+    the real current. The per-phase value must win.
+    """
+    data = {"current_l1": 9.38, "current_l2": 0, "current_l3": 0}
+    assert _compute_live_current(data, 30.37, 2087, 230, 1) == 9.4
+
+
+def test_compute_live_current_power_beats_stale_total():
+    """Power-derived value wins over a stale non-phased total too."""
+    assert _compute_live_current({}, 30.37, 2300, 230, 1) == 10.0
+
+
+def test_compute_live_current_single_phase_average():
+    """Single-phase current comes from the active phase, not stale total."""
+    data = {"current_l1": 9.0, "current_l2": 0, "current_l3": 0}
+    assert _compute_live_current(data, None, 2080, 230, 1) == 9.0
+
+
+def test_compute_live_current_three_phase_average():
+    """Three-phase balanced current is the per-phase value."""
+    data = {"current_l1": 16.0, "current_l2": 16.0, "current_l3": 16.0}
+    assert _compute_live_current(data, None, 11000, 230, 3) == 16.0
+
+
+def test_compute_live_current_derived_from_power_single_phase():
+    """Falls back to P/V when no phase currents are reported."""
+    assert _compute_live_current({}, None, 2300, 230, 1) == 10.0
+
+
+def test_compute_live_current_derived_from_power_three_phase():
+    """Three-phase derivation uses sqrt(3)."""
+    assert _compute_live_current({}, None, 11000, 230, 3) == 27.6
+
+
+def test_compute_live_current_none_when_no_data():
+    """Returns None when there is nothing to compute from."""
+    assert _compute_live_current({}, None, 0, 0, 1) is None
+
+
+async def test_meter_values_current_not_stale(charge_point):
+    """Current sensor must refresh from phases, not stick at an old total.
+
+    Regression for issue #15: once a stale total was stored it was never
+    recomputed, so the Current sensor stayed frozen while power dropped.
+    """
+    data = charge_point.coordinator.data
+    # Simulate a previously-stored stale total current.
+    data["current"] = 30.4
+
+    # The wallbox keeps sending a frozen non-phased total (30.4) alongside a
+    # fresh per-phase reading (9.0) - exactly what was seen live.
+    meter_value = [
+        {
+            "timestamp": datetime.utcnow().isoformat(),
+            "sampled_value": [
+                {"measurand": "Power.Active.Import", "value": "2080"},
+                {"measurand": "Current.Import", "value": "30.4"},
+                {"measurand": "Current.Import", "value": "9.0", "phase": "L1"},
+            ],
+        }
+    ]
+
+    await charge_point.on_meter_values(evse_id=1, meter_value=meter_value)
+
+    # Should reflect the fresh per-phase reading, not the stale non-phased 30.4
+    assert data["current_l1"] == 9.0
+    assert data["current"] == 9.0
+
+
+async def test_transaction_event_ended_resets_live_readings(charge_point):
+    """When the session ends, live readings must reset (issue #15)."""
+    data = charge_point.coordinator.data
+    data["current"] = 16.0
+    data["power"] = 3680.0
+    data["current_l1"] = 16.0
+
+    await charge_point.on_transaction_event(
+        event_type="Ended",
+        timestamp=datetime.utcnow().isoformat(),
+        trigger_reason="EVCommunicationLost",
+        seq_no=99,
+        transaction_info={"transaction_id": "tx-1", "charging_state": "Available"},
+    )
+
+    assert data["current"] == 0
+    assert data["power"] == 0
+    assert data["current_l1"] == 0
+
+
+# ==============================================================================
+# CURRENT LIMIT TIMING TESTS (issue #15 - startup overshoot)
+# ==============================================================================
+
+
+def _profile_purposes(mock_call):
+    """Extract the charging_profile_purpose of every SetChargingProfile sent."""
+    purposes = []
+    for call_args in mock_call.call_args_list:
+        msg = call_args.args[0]
+        purposes.append(msg.charging_profile.charging_profile_purpose)
+    return purposes
+
+
+async def test_set_current_limit_sends_tx_default_profile(coordinator):
+    """During a session both TxDefaultProfile and TxProfile are sent (issue #15)."""
+    mock_cp = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = "Accepted"
+    mock_cp.call = AsyncMock(return_value=mock_response)
+    coordinator.charge_point = mock_cp
+    coordinator.current_transaction_id = "tx-123"
+
+    result = await coordinator.async_set_current_limit(13.0)
+
+    assert result is True
+    purposes = _profile_purposes(mock_cp.call)
+    assert ChargingProfilePurposeEnumType.tx_default_profile in purposes
+    assert ChargingProfilePurposeEnumType.tx_profile in purposes
+    assert coordinator.data["current_limit"] == 13.0
+
+
+async def test_set_current_limit_without_transaction_uses_default_only(coordinator):
+    """Without an active session the TxDefaultProfile alone still sets the limit."""
+    mock_cp = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = "Accepted"
+    mock_cp.call = AsyncMock(return_value=mock_response)
+    coordinator.charge_point = mock_cp
+    coordinator.current_transaction_id = None
+
+    result = await coordinator.async_set_current_limit(10.0)
+
+    assert result is True
+    purposes = _profile_purposes(mock_cp.call)
+    assert purposes == [ChargingProfilePurposeEnumType.tx_default_profile]
+    assert coordinator.data["current_limit"] == 10.0
+
+
+async def test_set_current_limit_no_wallbox(coordinator):
+    """Setting the limit fails cleanly when the wallbox is not connected."""
+    coordinator.charge_point = None
+
+    result = await coordinator.async_set_current_limit(16.0)
+
+    assert result is False
+
+
+async def test_apply_limit_on_transaction_start(coordinator):
+    """A starting transaction triggers an immediate limit push (issue #15)."""
+    coordinator.charge_point = MagicMock()
+    coordinator.data["current_limit"] = 13.0
+    coordinator.async_set_current_limit = AsyncMock(return_value=True)
+
+    await coordinator.async_apply_limit_on_transaction_start()
+
+    coordinator.async_set_current_limit.assert_called_once_with(13.0)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -646,13 +646,20 @@ async def test_async_set_current_limit(coordinator):
 
 
 async def test_async_set_current_limit_no_transaction(coordinator):
-    """Test set current limit fails without transaction."""
-    coordinator.charge_point = MagicMock()
+    """Without a transaction the limit is still set via TxDefaultProfile (#15)."""
+    mock_charge_point = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = "Accepted"
+    mock_charge_point.call = AsyncMock(return_value=mock_response)
+
+    coordinator.charge_point = mock_charge_point
     coordinator.current_transaction_id = None
 
     result = await coordinator.async_set_current_limit(16.0)
 
-    assert result is False
+    assert result is True
+    purposes = _profile_purposes(mock_charge_point.call)
+    assert purposes == [ChargingProfilePurposeEnumType.tx_default_profile]
 
 
 async def test_async_trigger_meter_values(coordinator):


### PR DESCRIPTION
## Summary

Fixes **#14** and **#15**, both related to OCPP behaviour with the BMW/Delta wallboxes.

### #14 — `NotifyEVChargingNeeds` (OCPP 2.0.1)
Chargers that perform ISO 15118 high-level charging-needs negotiation send `NotifyEVChargingNeeds`. With no handler registered, the `ocpp` library replied with a `CallError` and flooded the HA log. Added an `@on("NotifyEVChargingNeeds")` handler that acknowledges the message (`Accepted`), mirroring the existing `NotifyEvent` handler.

### #15 — current limit applied with a ~2 min delay at session start
The integration only used `TxProfile`, which requires an active `transaction_id`. So when a session started, the wallbox charged at full power until the first poll detected the transaction and pushed the profile (~2 min), which could trip the supplier's main breaker.

- Install a **`TxDefaultProfile`** (no transaction needed) on connect and on every limit change — the wallbox now starts each session at the configured limit.
- Push the limit **immediately** on `TransactionEvent(event_type="Started")`.
- Setting the limit no longer requires an active transaction.

### #15 — `Current` sensor stuck at the last value
The live current was only computed when missing, so once a stale value was stored it never refreshed (power dropped, current stayed frozen). It is now recomputed on **every** meter update, with priority **per-phase → power/voltage → reported total**. The Delta firmware freezes its non-phased total register while the per-phase readings track reality, so per-phase wins. Live readings are also reset when the session ends.

### Refactor
- Shared `_send_charging_profile()` helper.
- Unified `L1`/`L1-N` phase labels between the `MeterValues` and `TransactionEvent` paths.

## Testing

- Unit tests added (`tests/test_coordinator.py`); full suite green (113 passed).
- **Verified live against a real BMW wallbox while a car was charging:**
  - Lowering the limit 63A → 10A: power dropped 6.3 kW → 2.0 kW and the `Current` sensor correctly followed (30A → 9.3A) instead of sticking.
  - Raising back 10A → 63A: power and current recovered.
  - No errors in the HA log after the change.

## Notes
A full HA restart is required to load the new code (reloading the config entry does not reimport the module).
