### PR TITLE
fix: serialise OCPP calls to stop current-limit desync (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2026-07-02
+
+### Fixed
+
+- **Wallbox stuck at its previous current limit after an automated `SetChargingProfile`** - Every OCPP command wrapped `call()` in a 15s timeout shorter than the `ocpp` library's own 30s response timeout. When the Delta firmware was slow to answer (e.g. mid ISO 15118 negotiation), the outer timeout cancelled the in-flight request; the wallbox's late reply was then orphaned in the library's response queue and every following response was read one slot too early (`Ignoring response with unknown unique id`), so `SetChargingProfile` was silently ignored and the current stuck at its last value. A house-load automation firing repeatedly (concurrently with the background meter poll) made the desync permanent, while isolated manual changes did not. Commands are now serialised through a single helper that relies on the library's own response timeout instead of a shorter external one ([#14](https://github.com/JoaoPedroBelo/bmw-wallbox-ha/issues/14))
+- **`NotifyChargingLimit` / `ClearedChargingLimit` log spam** - The BMW/Delta Gen 4 firmware sends these messages (even with no car charging, e.g. `chargingLimitSource: 'SO'`). Without handlers the OCPP library logged `KeyError` / `NotImplementedError` repeatedly. They are now acknowledged cleanly, same approach as `NotifyEVChargingNeeds` ([#14](https://github.com/JoaoPedroBelo/bmw-wallbox-ha/issues/14))
+
+### Changed
+
+- Startup messages about the firmware rejecting `StopTxOnEVSideDisconnect` and `TxDefaultProfile` are now logged at INFO with an explanation instead of as warnings - they are expected on BMW/Delta Gen 4 firmware and pause/resume and per-session limits still work correctly ([#14](https://github.com/JoaoPedroBelo/bmw-wallbox-ha/issues/14))
+
 ## [1.7.0] - 2026-06-20
 
 ### Added

--- a/custom_components/bmw_wallbox/coordinator.py
+++ b/custom_components/bmw_wallbox/coordinator.py
@@ -50,6 +50,24 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# --- OCPP call serialisation / timeout (issue #14) ---
+# The ocpp library serialises outgoing calls and matches every response to its
+# request through an internal queue (see charge_point._get_specific_response).
+# Cancelling a call() while it is still waiting for a response - which a short
+# external asyncio.wait_for does - leaves the wallbox's late reply orphaned in
+# that queue with no waiter. The next call then reads that stale reply first
+# ("Ignoring response with unknown unique id"), so every response is off by one
+# and SetChargingProfile appears to be ignored while the current stays stuck at
+# its previous value. Under a house-load automation firing SetChargingProfile
+# repeatedly (concurrently with the background meter poll) the orphans pile up
+# and the desync becomes permanent.
+#
+# Fix: let the library's own response_timeout be the single authority on how
+# long to wait (never a shorter external one that cancels mid-flight) and keep
+# only a slightly longer backstop for a genuinely wedged socket.
+OCPP_RESPONSE_TIMEOUT = 20.0
+OCPP_CALL_BACKSTOP_TIMEOUT = 30.0
+
 
 def _compute_live_current(
     data: dict[str, Any],
@@ -98,10 +116,19 @@ class WallboxChargePoint(cp):
     """ChargePoint handler for the BMW wallbox."""
 
     def __init__(
-        self, charge_point_id: str, websocket, coordinator: BMWWallboxCoordinator
+        self,
+        charge_point_id: str,
+        websocket,
+        coordinator: BMWWallboxCoordinator,
+        response_timeout: float = OCPP_RESPONSE_TIMEOUT,
     ):
-        """Initialize the ChargePoint."""
-        super().__init__(charge_point_id, websocket)
+        """Initialize the ChargePoint.
+
+        ``response_timeout`` is the single authority on how long we wait for a
+        wallbox reply; command paths must not wrap ``call()`` in a shorter
+        timeout (issue #14 - see OCPP_RESPONSE_TIMEOUT).
+        """
+        super().__init__(charge_point_id, websocket, response_timeout=response_timeout)
         self.coordinator = coordinator
         self.current_transaction_id: str | None = None
         _LOGGER.info("Initialized ChargePoint: %s", charge_point_id)
@@ -497,6 +524,29 @@ class WallboxChargePoint(cp):
             status=NotifyEVChargingNeedsStatusEnumType.accepted
         )
 
+    @on("NotifyChargingLimit")
+    async def on_notify_charging_limit(self, **kwargs):
+        """Handle NotifyChargingLimit (OCPP 2.0.1).
+
+        The BMW/Delta Gen 4 firmware sends this (even with no car charging, e.g.
+        chargingLimitSource 'SO') to report an externally imposed charging limit.
+        Without a handler the ocpp library replies with a CallError
+        (NotImplementedError) and floods the HA log. We just acknowledge it. See
+        issue #14, same approach as NotifyEVChargingNeeds / NotifyEvent.
+        """
+        _LOGGER.debug("NotifyChargingLimit received: %s", kwargs)
+        return call_result.NotifyChargingLimit()
+
+    @on("ClearedChargingLimit")
+    async def on_cleared_charging_limit(self, **kwargs):
+        """Handle ClearedChargingLimit (OCPP 2.0.1).
+
+        The counterpart of NotifyChargingLimit - sent when an external charging
+        limit is lifted. Acknowledged for the same reason (issue #14).
+        """
+        _LOGGER.debug("ClearedChargingLimit received: %s", kwargs)
+        return call_result.ClearedChargingLimit()
+
 
 class BMWWallboxCoordinator(DataUpdateCoordinator):
     """Class to manage fetching BMW Wallbox data."""
@@ -520,6 +570,8 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
         self.charge_point: WallboxChargePoint | None = None
         self.current_transaction_id: str | None = None
         self.device_info: dict[str, Any] = {}
+        # Serialises every outbound OCPP call (see _ocpp_call, issue #14).
+        self._call_lock = asyncio.Lock()
 
         # Initialize data
         self.data: dict[str, Any] = {
@@ -569,6 +621,31 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
             "current_limit": config.get(CONF_MAX_CURRENT, DEFAULT_MAX_CURRENT),
         }
 
+    async def _ocpp_call(self, payload: Any) -> Any:
+        """Send one OCPP request, serialised and with a single authoritative timeout.
+
+        Every wallbox command and background poll funnels through here so that:
+
+        * only one request is ever in flight - this keeps multi-step sequences
+          (e.g. ClearChargingProfile then SetChargingProfile) from interleaving
+          with the periodic meter poll, and
+        * ``call()`` is never wrapped in a timeout shorter than the library's own
+          ``response_timeout``. A shorter external timeout used to cancel the
+          request mid-flight; the wallbox's late reply was then orphaned in the
+          ocpp response queue, desyncing every following response so
+          SetChargingProfile appeared ignored and the current stuck at its
+          previous value (issue #14).
+
+        Raises ``TimeoutError`` if the wallbox never answers (backstop), or
+        ``RuntimeError`` if no wallbox is connected.
+        """
+        if not self.charge_point:
+            raise RuntimeError("Wallbox not connected")
+        async with self._call_lock:
+            return await asyncio.wait_for(
+                self.charge_point.call(payload), OCPP_CALL_BACKSTOP_TIMEOUT
+            )
+
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from the wallbox."""
         # When there's an active transaction, proactively request fresh meter values.
@@ -598,9 +675,8 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
                 variable=VariableType(name="StopTxOnEVSideDisconnect"),
             )
 
-            response = await asyncio.wait_for(
-                self.charge_point.call(call.SetVariables(set_variable_data=[set_var])),
-                timeout=15.0,
+            response = await self._ocpp_call(
+                call.SetVariables(set_variable_data=[set_var])
             )
 
             if response.set_variable_result:
@@ -610,8 +686,13 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
                 if status == "Accepted":
                     _LOGGER.info("✅ Wallbox configured for pause/resume!")
                 else:
-                    _LOGGER.warning(
-                        "⚠️ Could not configure StopTxOnEVSideDisconnect: %s", status
+                    # Delta Gen 4 firmware rejects this variable, yet pause still
+                    # works via a 0A SetChargingProfile - so this is informational,
+                    # not a real failure (issue #14).
+                    _LOGGER.info(
+                        "StopTxOnEVSideDisconnect not settable (%s); pause/resume "
+                        "still works via a 0A charging profile",
+                        status,
                     )
         except Exception as e:
             _LOGGER.warning("Could not configure StopTxOnEVSideDisconnect: %s", e)
@@ -703,14 +784,11 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
             from ocpp.v201 import call as ocpp_call
             from ocpp.v201.enums import MessageTriggerEnumType
 
-            response = await asyncio.wait_for(
-                self.charge_point.call(
-                    ocpp_call.TriggerMessage(
-                        requested_message=MessageTriggerEnumType.transaction_event,
-                        evse={"id": 1, "connector_id": 1},
-                    )
-                ),
-                timeout=15.0,
+            response = await self._ocpp_call(
+                ocpp_call.TriggerMessage(
+                    requested_message=MessageTriggerEnumType.transaction_event,
+                    evse={"id": 1, "connector_id": 1},
+                )
             )
 
             _LOGGER.info("Transaction recovery trigger response: %s", response.status)
@@ -821,15 +899,12 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
                     type=IdTokenEnumType.no_authorization,
                 )
 
-            response = await asyncio.wait_for(
-                self.charge_point.call(
-                    call.RequestStartTransaction(
-                        id_token=id_token,
-                        remote_start_id=int(datetime.utcnow().timestamp()),
-                        evse_id=1,
-                    )
-                ),
-                timeout=15.0,
+            response = await self._ocpp_call(
+                call.RequestStartTransaction(
+                    id_token=id_token,
+                    remote_start_id=int(datetime.utcnow().timestamp()),
+                    evse_id=1,
+                )
             )
 
             _LOGGER.info("RequestStartTransaction response: %s", response.status)
@@ -881,13 +956,8 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
                             charging_schedule=[schedule],
                         )
 
-                        profile_response = await asyncio.wait_for(
-                            self.charge_point.call(
-                                call.SetChargingProfile(
-                                    evse_id=1, charging_profile=profile
-                                )
-                            ),
-                            timeout=15.0,
+                        profile_response = await self._ocpp_call(
+                            call.SetChargingProfile(evse_id=1, charging_profile=profile)
                         )
                         _LOGGER.info(
                             "SetChargingProfile response: %s", profile_response.status
@@ -987,10 +1057,7 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
             await status_callback("Sending reset command to wallbox...")
 
         try:
-            response = await asyncio.wait_for(
-                self.charge_point.call(call.Reset(type=ResetEnumType.immediate)),
-                timeout=15.0,
-            )
+            response = await self._ocpp_call(call.Reset(type=ResetEnumType.immediate))
 
             _LOGGER.info("Reset response: %s", response.status)
 
@@ -1100,13 +1167,8 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
         )
 
         try:
-            response = await asyncio.wait_for(
-                self.charge_point.call(
-                    call.GetTransactionStatus(
-                        transaction_id=self.current_transaction_id
-                    )
-                ),
-                timeout=10.0,
+            response = await self._ocpp_call(
+                call.GetTransactionStatus(transaction_id=self.current_transaction_id)
             )
 
             _LOGGER.info(
@@ -1190,9 +1252,7 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
             # First clear ALL existing profiles to ensure clean state (like resume does)
             _LOGGER.info("Clearing ALL charging profiles first...")
             try:
-                clear_response = await asyncio.wait_for(
-                    self.charge_point.call(call.ClearChargingProfile()), timeout=10.0
-                )
+                clear_response = await self._ocpp_call(call.ClearChargingProfile())
                 _LOGGER.info("ClearChargingProfile response: %s", clear_response.status)
             except Exception as e:
                 _LOGGER.debug("ClearChargingProfile failed (OK to ignore): %s", e)
@@ -1218,11 +1278,8 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
                 charging_schedule=[schedule],
             )
 
-            response = await asyncio.wait_for(
-                self.charge_point.call(
-                    call.SetChargingProfile(evse_id=1, charging_profile=profile)
-                ),
-                timeout=15.0,
+            response = await self._ocpp_call(
+                call.SetChargingProfile(evse_id=1, charging_profile=profile)
             )
 
             _LOGGER.info("Pause response: %s", response.status)
@@ -1347,9 +1404,7 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
             _LOGGER.info("Clearing ALL charging profiles first...")
             try:
                 # Clear without specifying ID = clear all profiles
-                clear_response = await asyncio.wait_for(
-                    self.charge_point.call(call.ClearChargingProfile()), timeout=10.0
-                )
+                clear_response = await self._ocpp_call(call.ClearChargingProfile())
                 _LOGGER.info(
                     "ClearChargingProfile (all) response: %s", clear_response.status
                 )
@@ -1379,11 +1434,8 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
                 charging_schedule=[schedule],
             )
 
-            response = await asyncio.wait_for(
-                self.charge_point.call(
-                    call.SetChargingProfile(evse_id=1, charging_profile=profile)
-                ),
-                timeout=15.0,
+            response = await self._ocpp_call(
+                call.SetChargingProfile(evse_id=1, charging_profile=profile)
             )
 
             _LOGGER.info("Resume response: %s", response.status)
@@ -1486,17 +1538,26 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
             limit,
         )
 
-        response = await asyncio.wait_for(
-            self.charge_point.call(
-                call.SetChargingProfile(evse_id=1, charging_profile=profile)
-            ),
-            timeout=15.0,
+        response = await self._ocpp_call(
+            call.SetChargingProfile(evse_id=1, charging_profile=profile)
         )
 
         status_str = str(response.status)
         accepted = status_str == "Accepted" or "accepted" in status_str.lower()
         if accepted:
             _LOGGER.info("✅ %s set to %sA - accepted by wallbox", purpose, limit)
+        elif purpose == ChargingProfilePurposeEnumType.tx_default_profile:
+            # Some firmware (BMW/Delta Gen 4) doesn't accept a persistent
+            # TxDefaultProfile but honours the per-session TxProfile we send
+            # alongside it, so the limit still applies. Keep this informational
+            # rather than a scary warning (issue #14).
+            _LOGGER.info(
+                "%s (%sA) not accepted by wallbox: %s - the per-session profile "
+                "still applies the limit",
+                purpose,
+                limit,
+                response.status,
+            )
         else:
             _LOGGER.warning(
                 "⚠️ %s (%sA) rejected by wallbox: %s", purpose, limit, response.status
@@ -1618,14 +1679,11 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
             from ocpp.v201 import call as ocpp_call
             from ocpp.v201.enums import MessageTriggerEnumType
 
-            response = await asyncio.wait_for(
-                self.charge_point.call(
-                    ocpp_call.TriggerMessage(
-                        requested_message=MessageTriggerEnumType.meter_values,
-                        evse={"id": 1, "connector_id": 1},
-                    )
-                ),
-                timeout=15.0,
+            response = await self._ocpp_call(
+                ocpp_call.TriggerMessage(
+                    requested_message=MessageTriggerEnumType.meter_values,
+                    evse={"id": 1, "connector_id": 1},
+                )
             )
 
             _LOGGER.info("TriggerMessage response: %s", response.status)
@@ -1660,9 +1718,8 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
                 variable=VariableType(name="StatusLedBrightness"),
             )
 
-            response = await asyncio.wait_for(
-                self.charge_point.call(call.SetVariables(set_variable_data=[set_var])),
-                timeout=15.0,
+            response = await self._ocpp_call(
+                call.SetVariables(set_variable_data=[set_var])
             )
 
             # Check result

--- a/custom_components/bmw_wallbox/docs/PATTERNS.md
+++ b/custom_components/bmw_wallbox/docs/PATTERNS.md
@@ -128,28 +128,41 @@ class BMWWallboxPowerSensor(BMWWallboxSensorBase):
 
 ---
 
-### Pattern: Sending OCPP Commands with Timeout
+### Pattern: Sending OCPP Commands
 
-**Always wrap `call()` in `asyncio.wait_for()` with 15 second timeout.**
+**Always send commands through `self._ocpp_call(...)`. Never call
+`self.charge_point.call()` directly, and never wrap it in your own
+`asyncio.wait_for()`.**
 
 ```python
-# ✅ CORRECT: With timeout
+# ✅ CORRECT: go through the serialised helper
 try:
-    response = await asyncio.wait_for(
-        self.charge_point.call(
-            call.SetChargingProfile(evse_id=1, charging_profile=profile)
-        ),
-        timeout=15.0
+    response = await self._ocpp_call(
+        call.SetChargingProfile(evse_id=1, charging_profile=profile)
     )
-except asyncio.TimeoutError:
+except TimeoutError:
     _LOGGER.error("Command timed out!")
     return False
 
-# ❌ WRONG: No timeout (can hang forever)
-response = await self.charge_point.call(
-    call.SetChargingProfile(evse_id=1, charging_profile=profile)
+# ❌ WRONG: a short external timeout cancels the in-flight request, orphaning
+# the wallbox's reply in the ocpp response queue. Every following response is
+# then read one slot too early ("Ignoring response with unknown unique id") and
+# the wallbox appears to ignore SetChargingProfile, staying stuck at its last
+# limit. This is issue #14 - do not do it.
+response = await asyncio.wait_for(
+    self.charge_point.call(
+        call.SetChargingProfile(evse_id=1, charging_profile=profile)
+    ),
+    timeout=15.0,
 )
 ```
+
+`_ocpp_call` serialises every request behind a single lock and relies on the
+ocpp library's own `response_timeout` (`OCPP_RESPONSE_TIMEOUT`) as the single
+authority on how long to wait, with a slightly longer backstop
+(`OCPP_CALL_BACKSTOP_TIMEOUT`) only for a genuinely wedged socket. It raises
+`TimeoutError` if the wallbox never answers, so command paths still handle
+`TimeoutError` exactly as before.
 
 ---
 

--- a/custom_components/bmw_wallbox/manifest.json
+++ b/custom_components/bmw_wallbox/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "ocpp>=0.20.0"
   ],
-  "version": "1.7.0"
+  "version": "1.7.1"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,12 +1,19 @@
 """Test BMW Wallbox coordinator."""
 
+import asyncio
+import contextlib
 from datetime import datetime
+import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from ocpp.v201.enums import ChargingProfilePurposeEnumType
+from ocpp.v201 import call, call_result
+from ocpp.v201.enums import ChargingProfilePurposeEnumType, MessageTriggerEnumType
 import pytest
 
 from custom_components.bmw_wallbox.coordinator import (
+    OCPP_CALL_BACKSTOP_TIMEOUT,
+    OCPP_RESPONSE_TIMEOUT,
     BMWWallboxCoordinator,
     WallboxChargePoint,
     _compute_live_current,
@@ -355,6 +362,33 @@ async def test_notify_ev_charging_needs_handler(charge_point):
     # Should not raise exception and must return an Accepted status
     assert response is not None
     assert response.status == "Accepted"
+
+
+async def test_notify_charging_limit_handler(charge_point):
+    """Test NotifyChargingLimit handler (issue #14).
+
+    The BMW/Delta Gen 4 firmware sends NotifyChargingLimit (e.g. with
+    chargingLimitSource 'SO') even when no car is charging. Without a handler
+    the ocpp library raises NotImplementedError and floods the HA log with
+    KeyError: 'NotifyChargingLimit'.
+    """
+    response = await charge_point.on_notify_charging_limit(
+        charging_limit={"charging_limit_source": "SO"},
+    )
+
+    assert response is not None
+    assert isinstance(response, call_result.NotifyChargingLimit)
+
+
+async def test_cleared_charging_limit_handler(charge_point):
+    """Test ClearedChargingLimit handler (issue #14 - counterpart message)."""
+    response = await charge_point.on_cleared_charging_limit(
+        charging_limit_source="SO",
+        evse_id=1,
+    )
+
+    assert response is not None
+    assert isinstance(response, call_result.ClearedChargingLimit)
 
 
 # ==============================================================================
@@ -943,3 +977,153 @@ async def test_apply_limit_on_transaction_start(coordinator):
     await coordinator.async_apply_limit_on_transaction_start()
 
     coordinator.async_set_current_limit.assert_called_once_with(13.0)
+
+
+# ==============================================================================
+# OCPP CALL SERIALISATION / RESPONSE-QUEUE DESYNC TESTS (issue #14)
+# ==============================================================================
+
+
+class _FakeWallboxConnection:
+    """Minimal websockets-like connection that drives the real ocpp pump.
+
+    It replies to every Call (message type 2) with a CallResult
+    {"status": "Accepted"} after ``response_delay`` seconds, so tests can
+    exercise the library's real request/response matching (self._response_queue
+    + self._get_specific_response) that issue #14 desynced.
+    """
+
+    def __init__(self, response_delay: float = 0.0):
+        self.response_delay = response_delay
+        self.sent: list[str] = []
+        self._incoming: asyncio.Queue[str] = asyncio.Queue()
+
+    async def send(self, message: str) -> None:
+        self.sent.append(message)
+        data = json.loads(message)
+        if data[0] == 2:  # Call -> schedule a matching CallResult
+            asyncio.create_task(self._reply(data[1]))
+
+    async def _reply(self, unique_id: str) -> None:
+        if self.response_delay:
+            await asyncio.sleep(self.response_delay)
+        await self._incoming.put(json.dumps([3, unique_id, {"status": "Accepted"}]))
+
+    async def recv(self) -> str:
+        return await self._incoming.get()
+
+
+def _meter_trigger():
+    return call.TriggerMessage(
+        requested_message=MessageTriggerEnumType.meter_values,
+        evse={"id": 1, "connector_id": 1},
+    )
+
+
+async def test_ocpp_call_raises_without_wallbox(coordinator):
+    """_ocpp_call fails fast (not silently) when no wallbox is connected."""
+    coordinator.charge_point = None
+
+    with pytest.raises(RuntimeError):
+        await coordinator._ocpp_call(_meter_trigger())
+
+
+async def test_ocpp_call_serialises_concurrent_calls(coordinator):
+    """Only one OCPP request may be in flight at a time (issue #14).
+
+    Interleaved requests were part of what desynced the response queue; the
+    coordinator lock must serialise every call regardless of how many callers
+    fire concurrently.
+    """
+    in_flight = 0
+    max_in_flight = 0
+
+    async def fake_call(_payload):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.02)
+        in_flight -= 1
+        resp = MagicMock()
+        resp.status = "Accepted"
+        return resp
+
+    cp = MagicMock()
+    cp.call = fake_call
+    coordinator.charge_point = cp
+
+    await asyncio.gather(*(coordinator._ocpp_call(MagicMock()) for _ in range(8)))
+
+    assert max_in_flight == 1
+
+
+async def test_ocpp_call_uses_authoritative_timeout():
+    """The wallbox response_timeout is the single authority (issue #14).
+
+    A shorter external timeout would cancel an in-flight call() and orphan the
+    reply. The backstop must therefore be longer than the library's own
+    response_timeout, and the charge point must be built with it.
+    """
+    assert OCPP_CALL_BACKSTOP_TIMEOUT > OCPP_RESPONSE_TIMEOUT
+
+    cp = WallboxChargePoint("CP", MagicMock(), MagicMock())
+    assert cp._response_timeout == OCPP_RESPONSE_TIMEOUT
+
+
+async def test_ocpp_call_stays_in_sync_through_real_pump(coordinator, caplog):
+    """Rapid calls through _ocpp_call each get their own reply (issue #14).
+
+    Runs against the real ocpp message pump: every _ocpp_call must resolve to a
+    matching CallResult with no "Ignoring response with unknown unique id"
+    desync, even when the wallbox is slow enough that a short external timeout
+    would have cancelled the request mid-flight.
+    """
+    conn = _FakeWallboxConnection(response_delay=0.05)
+    cp = WallboxChargePoint("CP", conn, coordinator)
+    coordinator.charge_point = cp
+    pump = asyncio.create_task(cp.start())
+
+    try:
+        with caplog.at_level(logging.ERROR, logger="ocpp"):
+            results = await asyncio.gather(
+                *(coordinator._ocpp_call(_meter_trigger()) for _ in range(10))
+            )
+    finally:
+        pump.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await pump
+
+    assert len(results) == 10
+    assert all(r.status == "Accepted" for r in results)
+    assert "unknown unique id" not in caplog.text.lower()
+
+
+async def test_short_external_timeout_desyncs_queue_regression(coordinator, caplog):
+    """Characterises the issue #14 root cause the fix removes.
+
+    Wrapping call() in an external timeout shorter than the wallbox's reply
+    cancels the in-flight request; the late reply is then orphaned in the ocpp
+    response queue and the *next* call reads it first, logging "Ignoring
+    response with unknown unique id". This is exactly the log line the reporter
+    saw, and precisely what _ocpp_call avoids by never using a short external
+    timeout.
+    """
+    conn = _FakeWallboxConnection(response_delay=0.2)
+    cp = WallboxChargePoint("CP", conn, coordinator)
+    coordinator.charge_point = cp
+    pump = asyncio.create_task(cp.start())
+
+    try:
+        with caplog.at_level(logging.ERROR, logger="ocpp"):
+            # Old pattern: external timeout (0.05s) shorter than the reply (0.2s)
+            # cancels the request mid-flight.
+            with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+                await asyncio.wait_for(cp.call(_meter_trigger()), 0.05)
+            # The orphaned reply now poisons the following call.
+            await cp.call(_meter_trigger())
+
+        assert "unknown unique id" in caplog.text.lower()
+    finally:
+        pump.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await pump


### PR DESCRIPTION
## Summary

Fixes the follow-up problems reported on [#14](https://github.com/JoaoPedroBelo/bmw-wallbox-ha/issues/14) after the original `NotifyEVChargingNeeds` fix (#16). The reporter (BMW Wallbox Plus Gen 4 / Delta) confirmed manual current changes are now instant, but hit three remaining issues — all addressed here.

### 1. Critical: wallbox stuck at its previous limit after automated `SetChargingProfile`

**Root cause.** Every OCPP command wrapped `self.charge_point.call()` in an external `asyncio.wait_for(..., timeout=15.0)`, while the `ocpp` library already applies its own 30s `response_timeout`. When the Delta firmware was slow to answer (e.g. mid ISO 15118 negotiation), the **shorter outer timeout cancelled the in-flight request**. The wallbox's late reply then landed in the library's internal response queue with no waiter — orphaned. The next call read that stale reply first (`Ignoring response with unknown unique id`, `action=None`), so every response was off-by-one and `SetChargingProfile` was effectively never applied → **stuck at 16A**. A house-load automation firing repeatedly (concurrently with the background meter poll) piled up orphans and made the desync permanent. Isolated manual changes never triggered it.

**Fix.** All 13 call sites now funnel through a single `_ocpp_call` helper that:
- serialises requests behind a coordinator-level lock, so multi-step sequences (Clear + Set) never interleave with the periodic poll; and
- never wraps `call()` in a timeout shorter than the library's own — the library's `response_timeout` (`OCPP_RESPONSE_TIMEOUT = 20s`) is the single authority, with a longer `OCPP_CALL_BACKSTOP_TIMEOUT = 30s` only for a genuinely wedged socket.

### 2. `NotifyChargingLimit` / `ClearedChargingLimit` log spam

The Delta firmware sends these (even idle, `chargingLimitSource: 'SO'`); without handlers the library logged `KeyError: 'NotifyChargingLimit'` repeatedly. Added `on_notify_charging_limit` + `on_cleared_charging_limit`, same pattern as the existing Notify\* handlers.

### 3. Alarming startup warnings

`StopTxOnEVSideDisconnect: Rejected` and `TxDefaultProfile (25A) rejected` are downgraded from `WARNING` to explanatory `INFO` — they are expected on this firmware (pause/resume and per-session limits still work), so they should not read as failures.

Also updated `docs/PATTERNS.md`, which explicitly labelled the bug-causing `wait_for(call(), 15s)` pattern as "✅ CORRECT" — a landmine for future contributors.

## Test plan

- [x] `pytest tests/` — **120 passed** (was 113; +7 new)
- [x] `ruff check` + `ruff format --check` clean across the package
- New regression tests in `tests/test_coordinator.py`:
  - [x] `on_notify_charging_limit` / `on_cleared_charging_limit` handlers acknowledge cleanly
  - [x] `_ocpp_call` serialises concurrent calls (asserts max 1 request in flight)
  - [x] `_ocpp_call` uses the library's authoritative timeout (backstop > response_timeout; charge point built with it)
  - [x] `_ocpp_call` raises when no wallbox is connected
  - [x] real-pump integration: 10 rapid calls all resolve correctly with **no** `unknown unique id` desync
  - [x] characterisation test that reproduces the exact `Ignoring response with unknown unique id` desync with the old short-timeout pattern (locks in *why* the fix matters)
- [ ] Live confirmation on real hardware of the house-load automation scenario (the one thing unit tests can't reproduce is the real slow-firmware timing)

Closes #14
