### PR TITLE
fix: clear charging profiles before mid-session limit changes (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2026-07-10
+
+### Fixed
+
+- **Mid-session current limit changes rejected by the wallbox ("stuck" charging current)** - Changing the charging current during an active session sent a `TxProfile` with `stack_level=1` and without clearing the previously installed profile. Delta Gen 4 firmware rejects profiles above stack level 0 and does not replace an existing profile with the same id - it rejects the duplicate, and once a transaction has seen such a rejection it keeps rejecting every subsequent profile (including the 0A pause, which then triggered the last-resort wallbox reboot) until a new transaction starts. The current-limit path now mirrors the proven pause/resume pattern: `ClearChargingProfile` first, then `TxProfile` (id 999, stack level 0) for immediate effect, then `TxDefaultProfile` (id 998) for the next session. Validated live: consecutive mid-charge changes (6→20→12→16A, plus a burst of 8 rapid automation-style changes) all applied within ~20s with zero rejections ([#14](https://github.com/JoaoPedroBelo/bmw-wallbox-ha/issues/14))
+- **Rejection reasons now logged** - When the wallbox rejects a charging profile, the `statusInfo` reason code (when provided) is now included in the warning instead of a bare `Rejected`
+
 ## [1.7.1] - 2026-07-02
 
 ### Fixed

--- a/custom_components/bmw_wallbox/coordinator.py
+++ b/custom_components/bmw_wallbox/coordinator.py
@@ -1559,8 +1559,24 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
                 response.status,
             )
         else:
+            # Surface the wallbox's own reason for the rejection - essential to
+            # debug firmware-specific refusals (issue #14).
+            reason = ""
+            status_info = getattr(response, "status_info", None)
+            if status_info:
+                if isinstance(status_info, dict):
+                    reason = (
+                        f" (reason={status_info.get('reason_code', '?')},"
+                        f" info={status_info.get('additional_info', '')})"
+                    )
+                else:
+                    reason = f" (status_info={status_info})"
             _LOGGER.warning(
-                "⚠️ %s (%sA) rejected by wallbox: %s", purpose, limit, response.status
+                "⚠️ %s (%sA) rejected by wallbox: %s%s",
+                purpose,
+                limit,
+                response.status,
+                reason,
             )
         return accepted
 
@@ -1589,25 +1605,44 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
         )
 
         try:
-            # TxDefaultProfile persists across sessions and applies from the start
-            # of the next transaction - prevents the startup overshoot.
-            ok_default = await self._send_charging_profile(
-                limit,
-                purpose=ChargingProfilePurposeEnumType.tx_default_profile,
-                profile_id=998,
-                stack_level=0,
-            )
+            # The Delta firmware does NOT replace an existing profile with the
+            # same id/stack - it rejects the duplicate. After any start/resume
+            # (which installs TxProfile id=999) every mid-session limit change
+            # was therefore Rejected (issue #14 retest, seen live). Clear first,
+            # exactly like the proven pause/resume paths do, then reinstall.
+            if self.current_transaction_id:
+                try:
+                    clear_response = await self._ocpp_call(call.ClearChargingProfile())
+                    _LOGGER.debug(
+                        "ClearChargingProfile before limit change: %s",
+                        clear_response.status,
+                    )
+                except Exception as e:
+                    _LOGGER.debug("ClearChargingProfile failed (OK to ignore): %s", e)
 
             # TxProfile takes effect immediately on the running session.
+            # stack_level 0 matches the pause/resume paths; some Delta firmware
+            # rejects any higher level (ChargingProfileMaxStackLevel=0), and
+            # TxProfile already outranks TxDefaultProfile by purpose alone.
             ok_tx = False
             if self.current_transaction_id:
                 ok_tx = await self._send_charging_profile(
                     limit,
                     purpose=ChargingProfilePurposeEnumType.tx_profile,
                     profile_id=999,
-                    stack_level=1,
+                    stack_level=0,
                     transaction_id=self.current_transaction_id,
                 )
+
+            # TxDefaultProfile persists across sessions and applies from the
+            # start of the next transaction - prevents the startup overshoot.
+            # Sent after the TxProfile so the running session is limited first.
+            ok_default = await self._send_charging_profile(
+                limit,
+                purpose=ChargingProfilePurposeEnumType.tx_default_profile,
+                profile_id=998,
+                stack_level=0,
+            )
 
             if ok_default or ok_tx:
                 # Track the new limit for future start/resume/connect operations

--- a/custom_components/bmw_wallbox/manifest.json
+++ b/custom_components/bmw_wallbox/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "ocpp>=0.20.0"
   ],
-  "version": "1.7.1"
+  "version": "1.7.2"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -915,13 +915,86 @@ async def test_transaction_event_ended_resets_live_readings(charge_point):
 # ==============================================================================
 
 
+def _set_profile_messages(mock_call):
+    """Return the SetChargingProfile payloads sent (skips e.g. Clear calls)."""
+    return [
+        c.args[0]
+        for c in mock_call.call_args_list
+        if hasattr(c.args[0], "charging_profile")
+    ]
+
+
 def _profile_purposes(mock_call):
     """Extract the charging_profile_purpose of every SetChargingProfile sent."""
-    purposes = []
-    for call_args in mock_call.call_args_list:
-        msg = call_args.args[0]
-        purposes.append(msg.charging_profile.charging_profile_purpose)
-    return purposes
+    return [
+        msg.charging_profile.charging_profile_purpose
+        for msg in _set_profile_messages(mock_call)
+    ]
+
+
+async def test_set_current_limit_clears_profiles_first_with_transaction(coordinator):
+    """Mid-session limit changes must clear existing profiles first (issue #14).
+
+    The Delta firmware does not replace a profile with the same id/stack - it
+    rejects the duplicate. After a start/resume installed TxProfile id=999,
+    every slider change was Rejected until profiles were cleared first (the
+    pause/resume paths already do this and are accepted).
+    """
+    mock_cp = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = "Accepted"
+    mock_cp.call = AsyncMock(return_value=mock_response)
+    coordinator.charge_point = mock_cp
+    coordinator.current_transaction_id = "tx-123"
+
+    assert await coordinator.async_set_current_limit(13.0) is True
+
+    sent = [type(c.args[0]).__name__ for c in mock_cp.call.call_args_list]
+    assert sent[0] == "ClearChargingProfile"
+    # TxProfile (immediate) before TxDefaultProfile (next-session persistence)
+    purposes = _profile_purposes(mock_cp.call)
+    assert purposes == [
+        ChargingProfilePurposeEnumType.tx_profile,
+        ChargingProfilePurposeEnumType.tx_default_profile,
+    ]
+
+
+async def test_set_current_limit_no_clear_without_transaction(coordinator):
+    """Without a session there is nothing to clear - TxDefault goes out alone."""
+    mock_cp = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = "Accepted"
+    mock_cp.call = AsyncMock(return_value=mock_response)
+    coordinator.charge_point = mock_cp
+    coordinator.current_transaction_id = None
+
+    assert await coordinator.async_set_current_limit(10.0) is True
+
+    sent = [type(c.args[0]).__name__ for c in mock_cp.call.call_args_list]
+    assert sent == ["SetChargingProfile"]
+
+
+async def test_set_current_limit_profiles_use_stack_level_zero(coordinator):
+    """Every profile the slider sends must use stack_level=0 (issue #14 retest).
+
+    Delta firmware with ChargingProfileMaxStackLevel=0 rejects any profile at a
+    higher stack level, so a TxProfile at stack 1 was accepted-by-tests but
+    Rejected by the real wallbox and the limit never applied mid-session.
+    TxProfile already outranks TxDefaultProfile by purpose alone.
+    """
+    mock_cp = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = "Accepted"
+    mock_cp.call = AsyncMock(return_value=mock_response)
+    coordinator.charge_point = mock_cp
+    coordinator.current_transaction_id = "tx-123"
+
+    assert await coordinator.async_set_current_limit(13.0) is True
+
+    stack_levels = [
+        msg.charging_profile.stack_level for msg in _set_profile_messages(mock_cp.call)
+    ]
+    assert stack_levels == [0, 0]
 
 
 async def test_set_current_limit_sends_tx_default_profile(coordinator):


### PR DESCRIPTION
## Summary

Fixes the remaining #14 symptom: **mid-session charging-current changes silently rejected by the wallbox**, leaving the current "stuck" at its previous value until a new transaction started.

### Root cause (validated live on real hardware)

The current-limit path sent a `TxProfile` with `stack_level=1` and did not clear the previously installed profile. Delta Gen 4 firmware:

1. rejects any charging profile above stack level 0 (`ChargingProfileMaxStackLevel=0`), and
2. does not replace an existing profile with the same id — it rejects the duplicate, and
3. once a transaction has seen such a rejection, it keeps rejecting **every** subsequent profile on that transaction — including the 0A pause, which then triggered the last-resort wallbox reboot — until a new transaction starts ("burned" transaction).

The pause/resume paths never hit this because they always send `ClearChargingProfile` first and use stack level 0 — which is why start/stop kept working while the slider didn't.

### Fix

`async_set_current_limit` now mirrors the proven pause/resume pattern:

1. `ClearChargingProfile` (best-effort, only when a transaction is active)
2. `TxProfile` (id 999, **stack level 0**) — immediate effect on the running session
3. `TxDefaultProfile` (id 998) — persists for the next session (issue #15 behaviour preserved)

Also: profile rejections now log the `statusInfo` reason code when the wallbox provides one, instead of a bare `Rejected`.

### Live validation (BMW i4 eDrive40 + BMW Wallbox Plus / Delta Gen 4)

| Test | Result |
|------|--------|
| 6A → 20A while charging | applied in 19s |
| 20A → 12A while charging | applied in 20s |
| 12A → 16A while charging | applied in 18s |
| Burst of 8 rapid automation-style changes (~5s apart) | all processed, zero rejections |
| Pause during active charge | clean pause (previously: rejected → nuke reboot) |

## Test plan

- [x] `pytest tests/` — **123 passed** (+2 new: clear-first ordering with/without transaction, stack-level-0 regression)
- [x] `ruff check` + `ruff format --check` clean
- [x] Live end-to-end validation on real hardware (table above)
- [ ] Reporter (iX1, iDrive 9) confirmation on v1.7.2

Refs #14
