### PR TITLE
fix: shield current-limit sequence from service-call cancellation

### DIFF
--- a/custom_components/bmw_wallbox/coordinator.py
+++ b/custom_components/bmw_wallbox/coordinator.py
@@ -586,6 +586,8 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
         self.device_info: dict[str, Any] = {}
         # Serialises every outbound OCPP call (see _ocpp_call, issue #14).
         self._call_lock = asyncio.Lock()
+        # Serialises whole limit-change sequences (see async_set_current_limit).
+        self._limit_lock = asyncio.Lock()
 
         # Initialize data
         self.data: dict[str, Any] = {
@@ -1619,6 +1621,14 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
         TxProfile bound to the active transaction so it takes effect immediately
         on the current session.
 
+        The OCPP sequence runs shielded from cancellation. HA cancels in-flight
+        service calls when e.g. a ``mode: restart`` automation re-triggers; an
+        abort between ClearChargingProfile and SetChargingProfile left the
+        wallbox with no profile at all, and the wallbox's late reply was
+        orphaned in the ocpp response queue ("Ignoring response with unknown
+        unique id"). The shield lets the sequence finish in the background
+        while the cancellation still propagates to the caller.
+
         Args:
             limit: Current limit in Amps (max = full speed)
 
@@ -1628,7 +1638,21 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
         if not self.charge_point:
             _LOGGER.error("❌ No wallbox connected - cannot set current limit")
             return False
+        return await asyncio.shield(self._set_current_limit(limit))
 
+    async def _set_current_limit(self, limit: float) -> bool:
+        """Run the clear/set profile sequence (see async_set_current_limit).
+
+        ``_limit_lock`` serialises whole sequences: a shielded sequence that
+        outlived its cancelled caller must not interleave with the next one,
+        or the newer SetChargingProfile reuses ids 999/998 without a Clear in
+        between and the Delta firmware rejects it as a duplicate.
+        """
+        async with self._limit_lock:
+            return await self._run_limit_sequence(limit)
+
+    async def _run_limit_sequence(self, limit: float) -> bool:
+        """Clear existing profiles and install the new limit."""
         _LOGGER.info(
             "⚡ Setting current limit to %sA (tx=%s)",
             limit,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -959,6 +959,105 @@ async def test_set_current_limit_clears_profiles_first_with_transaction(coordina
     ]
 
 
+async def test_set_current_limit_survives_cancellation(coordinator):
+    """A cancelled service call must not abort the profile sequence.
+
+    HA cancels in-flight service calls when a ``mode: restart`` automation
+    re-triggers. An abort between ClearChargingProfile and SetChargingProfile
+    left the wallbox with no profile at all and orphaned the late reply in the
+    ocpp response queue. The shielded sequence must run to completion even
+    when the caller is cancelled mid-flight.
+    """
+    release = asyncio.Event()
+    mock_response = MagicMock()
+    mock_response.status = "Accepted"
+
+    async def slow_call(payload):
+        await release.wait()
+        return mock_response
+
+    mock_cp = MagicMock()
+    mock_cp.call = AsyncMock(side_effect=slow_call)
+    coordinator.charge_point = mock_cp
+    coordinator.current_transaction_id = "tx-123"
+
+    task = asyncio.create_task(coordinator.async_set_current_limit(13.0))
+    # Let the sequence start and block on the first (Clear) call, then cancel
+    # the caller - exactly what HA does to the running automation action.
+    await asyncio.sleep(0)
+    while not mock_cp.call.call_args_list:
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Unblock the wallbox replies; the shielded sequence must still finish.
+    release.set()
+    async with asyncio.timeout(1):
+        while coordinator.data.get("current_limit") != 13.0:
+            await asyncio.sleep(0)
+
+    sent = [type(c.args[0]).__name__ for c in mock_cp.call.call_args_list]
+    assert sent[0] == "ClearChargingProfile"
+    assert _profile_purposes(mock_cp.call) == [
+        ChargingProfilePurposeEnumType.tx_profile,
+        ChargingProfilePurposeEnumType.tx_default_profile,
+    ]
+
+
+async def test_set_current_limit_sequences_do_not_interleave(coordinator):
+    """A shielded sequence that outlived its caller must finish before the next.
+
+    Without sequence-level serialisation, the newer SetChargingProfile reuses
+    ids 999/998 without a Clear in between and the Delta firmware rejects it
+    as a duplicate - the newest limit would silently fail to apply.
+    """
+    release = asyncio.Event()
+    mock_response = MagicMock()
+    mock_response.status = "Accepted"
+
+    async def slow_call(payload):
+        await release.wait()
+        return mock_response
+
+    mock_cp = MagicMock()
+    mock_cp.call = AsyncMock(side_effect=slow_call)
+    coordinator.charge_point = mock_cp
+    coordinator.current_transaction_id = "tx-123"
+
+    # First limit change gets cancelled mid-Clear (automation restart) ...
+    task1 = asyncio.create_task(coordinator.async_set_current_limit(15.0))
+    await asyncio.sleep(0)
+    while not mock_cp.call.call_args_list:
+        await asyncio.sleep(0)
+    task1.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task1
+
+    # ... and the restarted automation immediately requests a new limit.
+    task2 = asyncio.create_task(coordinator.async_set_current_limit(19.0))
+    await asyncio.sleep(0)
+    release.set()
+    assert await task2 is True
+
+    # Old sequence ran to completion first, then the new one - no interleaving.
+    sent = [type(c.args[0]).__name__ for c in mock_cp.call.call_args_list]
+    assert sent == [
+        "ClearChargingProfile",
+        "SetChargingProfile",
+        "SetChargingProfile",
+        "ClearChargingProfile",
+        "SetChargingProfile",
+        "SetChargingProfile",
+    ]
+    limits = [
+        msg.charging_profile.charging_schedule[0].charging_schedule_period[0].limit
+        for msg in _set_profile_messages(mock_cp.call)
+    ]
+    assert limits == [15.0, 15.0, 19.0, 19.0]
+    assert coordinator.data["current_limit"] == 19.0
+
+
 async def test_set_current_limit_no_clear_without_transaction(coordinator):
     """Without a session there is nothing to clear - TxDefault goes out alone."""
     mock_cp = MagicMock()


### PR DESCRIPTION
## Problem

Home Assistant cancels in-flight service calls when a `mode: restart` automation re-triggers while a previous run is still executing. Seen live (2026-07-12 log) with a house-load automation adjusting the current limit every few seconds:

1. The coordinator sends `ClearChargingProfile` and awaits the reply.
2. The automation re-triggers; HA logs `Restarting` and cancels the running action — killing the coordinator coroutine mid-sequence.
3. The wallbox's reply arrives with nobody waiting; on the next call the ocpp lib logs `Ignoring response with unknown unique id`.

Consequences observed in the log:
- A requested limit was skipped entirely (15A cancelled, jumped 24A → 19A).
- Sequences left half-done (TxProfile applied, TxDefaultProfile confirmation never consumed).
- Worst case: cancellation between Clear and Set leaves the wallbox with **no profile at all** until the next automation run — same desync class as #14/#17.

## Fix

- Run the clear/set profile sequence under `asyncio.shield`: a cancelled caller no longer aborts it; the sequence finishes in the background while the cancellation still propagates to the caller (the restarted automation brings the fresh value anyway).
- Serialise whole sequences with a dedicated `_limit_lock`: a shielded sequence that outlived its caller must not interleave with the next one, or the newer `SetChargingProfile` reuses ids 999/998 without a Clear in between and the Delta firmware rejects it as a duplicate — the newest limit would silently fail to apply.

## Tests

- `test_set_current_limit_survives_cancellation` — caller cancelled mid-Clear; the full Clear → TxProfile → TxDefaultProfile sequence still completes and `current_limit` is updated.
- `test_set_current_limit_sequences_do_not_interleave` — cancelled sequence + immediate new request: old sequence finishes first, then the new one runs with its own Clear; final limit is the newest. Red/green verified (fails without the lock).
- Full suite: 135 passed; ruff clean.

Not yet validated against the live wallbox — synthetic tests only.