### PR TITLE
ci: pin actions to commit SHAs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+# The workflows pin every action to a commit SHA, which is what stops a
+# compromised upstream tag from running in a job that holds `contents: write`.
+# Pins rot, so Dependabot is what keeps them current: it opens a PR with the new
+# SHA whenever an action publishes a release.
+#
+# The updates are grouped into a single PR: ungrouped, a week where four actions
+# cut a release means four PRs that each have to be reviewed and merged one at a
+# time, and they all touch the same workflow files.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate version tag
         run: |
@@ -33,13 +33,13 @@ jobs:
           echo "✅ Version numbers match!"
 
       - name: HACS validation
-        uses: hacs/action@main
+        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main @ 2026-07-31
         with:
           category: integration
         continue-on-error: true
 
       - name: Hassfest validation
-        uses: home-assistant/actions/hassfest@master
+        uses: home-assistant/actions/hassfest@ab22029681aa532bfe7de5774a9972d67bfbd2c0 # master @ 2026-07-31
 
   test:
     name: Run Tests
@@ -51,10 +51,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -80,7 +80,7 @@ jobs:
     needs: [validate, test]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -174,7 +174,7 @@ jobs:
           echo "✅ Created bmw_wallbox.zip"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           body_path: /tmp/release-notes.md
           files: bmw_wallbox.zip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -53,10 +53,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload coverage reports
         if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Validate with HACS
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
       - name: HACS validation
-        uses: "hacs/action@main"
+        uses: "hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa" # main @ 2026-07-31
         with:
           category: "integration"
 
@@ -21,6 +21,6 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Validate with hassfest
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
       - name: Hassfest validation
-        uses: "home-assistant/actions/hassfest@master"
+        uses: "home-assistant/actions/hassfest@ab22029681aa532bfe7de5774a9972d67bfbd2c0" # master @ 2026-07-31

--- a/custom_components/bmw_wallbox/docs/ARCHITECTURE.md
+++ b/custom_components/bmw_wallbox/docs/ARCHITECTURE.md
@@ -279,12 +279,13 @@ ssl_context.load_cert_chain(cert_path, key_path)
 
 # 2. Start WebSocket server (runs in background)
 self.server = await websockets.serve(
-    on_connect,           # Handler for new connections
-    "0.0.0.0",            # Listen on all interfaces
+    on_connect,  # Handler for new connections
+    "0.0.0.0",  # Listen on all interfaces
     self.config["port"],  # Default: 9000
     subprotocols=["ocpp2.0.1"],
     ssl=ssl_context,
 )
+
 
 # 3. on_connect creates WallboxChargePoint and starts message loop
 async def on_connect(websocket):
@@ -297,11 +298,13 @@ async def on_connect(websocket):
 ```python
 # Entities extend CoordinatorEntity which handles automatic updates
 
+
 class BMWWallboxPowerSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> float | None:
         # Called automatically when coordinator.data updates
         return self.coordinator.data.get("power")
+
 
 # In coordinator, after processing OCPP message:
 self.data["power"] = new_value

--- a/custom_components/bmw_wallbox/docs/CONSTANTS.md
+++ b/custom_components/bmw_wallbox/docs/CONSTANTS.md
@@ -204,6 +204,7 @@ Used for `extra_state_attributes` keys.
 ```python
 from .const import ATTR_TRANSACTION_ID, ATTR_CHARGING_STATE
 
+
 @property
 def extra_state_attributes(self) -> dict[str, Any]:
     return {
@@ -264,6 +265,7 @@ from .const import SENSOR_NEW_METRIC
 
 ```python
 """Constants for the BMW Wallbox integration."""
+
 from typing import Final
 
 DOMAIN: Final = "bmw_wallbox"

--- a/custom_components/bmw_wallbox/docs/CONTEXT.md
+++ b/custom_components/bmw_wallbox/docs/CONTEXT.md
@@ -101,7 +101,7 @@ All OCPP commands must use `asyncio.wait_for()` with timeout:
 ```python
 response = await asyncio.wait_for(
     self.charge_point.call(call.SomeCommand(...)),
-    timeout=15.0  # Always 15 seconds
+    timeout=15.0,  # Always 15 seconds
 )
 ```
 

--- a/custom_components/bmw_wallbox/docs/COORDINATOR.md
+++ b/custom_components/bmw_wallbox/docs/COORDINATOR.md
@@ -100,7 +100,9 @@ await coordinator.async_stop_server()
 **Location:** `coordinator.py:616-805`
 
 ```python
-async def async_start_charging(self, status_callback=None, allow_nuke: bool = True) -> dict:
+async def async_start_charging(
+    self, status_callback=None, allow_nuke: bool = True
+) -> dict:
     """Start/resume charging using SetChargingProfile(32A)."""
 ```
 
@@ -113,9 +115,9 @@ async def async_start_charging(self, status_callback=None, allow_nuke: bool = Tr
 **Returns:**
 ```python
 {
-    "success": bool,    # True if charging started/resumed
-    "message": str,     # User-friendly message
-    "action": str,      # "started", "resumed", "already_charging", "rejected", "nuked", "failed"
+    "success": bool,  # True if charging started/resumed
+    "message": str,  # User-friendly message
+    "action": str,  # "started", "resumed", "already_charging", "rejected", "nuked", "failed"
 }
 ```
 
@@ -498,17 +500,14 @@ See `OCPP_HANDLERS.md` for detailed handler documentation.
 Use the inherited `call()` method:
 
 ```python
-response = await self.charge_point.call(
-    call.CommandName(param=value)
-)
+response = await self.charge_point.call(call.CommandName(param=value))
 ```
 
 Always wrap in `asyncio.wait_for()` with timeout:
 
 ```python
 response = await asyncio.wait_for(
-    self.charge_point.call(call.CommandName(...)),
-    timeout=15.0
+    self.charge_point.call(call.CommandName(...)), timeout=15.0
 )
 ```
 

--- a/custom_components/bmw_wallbox/docs/DATA_SCHEMAS.md
+++ b/custom_components/bmw_wallbox/docs/DATA_SCHEMAS.md
@@ -11,240 +11,191 @@ coordinator.data: dict[str, Any] = {
     # ═══════════════════════════════════════════════════════════════════
     # CONNECTION STATUS
     # ═══════════════════════════════════════════════════════════════════
-    "connected": bool,           # True if OCPP WebSocket connected
-                                 # Default: False
-                                 # Source: on_connect(), on_heartbeat()
-
+    "connected": bool,  # True if OCPP WebSocket connected
+    # Default: False
+    # Source: on_connect(), on_heartbeat()
     "last_heartbeat": datetime | None,  # Last heartbeat timestamp
-                                        # Default: None
-                                        # Source: on_heartbeat()
-
+    # Default: None
+    # Source: on_heartbeat()
     # ═══════════════════════════════════════════════════════════════════
     # CHARGING STATE
     # ═══════════════════════════════════════════════════════════════════
-    "charging_state": str,       # OCPP charging state
-                                 # Values: "Charging", "SuspendedEVSE", "SuspendedEV",
-                                 #         "EVConnected", "Idle", "Unknown"
-                                 # Default: "Unknown"
-                                 # Source: TransactionEvent.transaction_info.charging_state
-
-    "connector_status": str,     # Physical connector status
-                                 # Values: "Available", "Occupied", "Reserved",
-                                 #         "Unavailable", "Faulted", "Unknown"
-                                 # Default: "Unknown"
-                                 # Source: StatusNotification.connector_status
-
-    "evse_id": int,              # EVSE identifier (always 1 for single-port)
-                                 # Default: 1
-                                 # Source: StatusNotification.evse_id
-
-    "connector_id": int,         # Connector identifier (always 1)
-                                 # Default: 1
-                                 # Source: StatusNotification.connector_id
-
+    "charging_state": str,  # OCPP charging state
+    # Values: "Charging", "SuspendedEVSE", "SuspendedEV",
+    #         "EVConnected", "Idle", "Unknown"
+    # Default: "Unknown"
+    # Source: TransactionEvent.transaction_info.charging_state
+    "connector_status": str,  # Physical connector status
+    # Values: "Available", "Occupied", "Reserved",
+    #         "Unavailable", "Faulted", "Unknown"
+    # Default: "Unknown"
+    # Source: StatusNotification.connector_status
+    "evse_id": int,  # EVSE identifier (always 1 for single-port)
+    # Default: 1
+    # Source: StatusNotification.evse_id
+    "connector_id": int,  # Connector identifier (always 1)
+    # Default: 1
+    # Source: StatusNotification.connector_id
     # ═══════════════════════════════════════════════════════════════════
     # TRANSACTION INFO
     # ═══════════════════════════════════════════════════════════════════
     "transaction_id": str | None,  # Active transaction UUID
-                                   # Default: None
-                                   # Source: TransactionEvent.transaction_info.transaction_id
-
-    "event_type": str | None,    # Transaction event type
-                                 # Values: "Started", "Updated", "Ended"
-                                 # Default: None
-                                 # Source: TransactionEvent.event_type
-
+    # Default: None
+    # Source: TransactionEvent.transaction_info.transaction_id
+    "event_type": str | None,  # Transaction event type
+    # Values: "Started", "Updated", "Ended"
+    # Default: None
+    # Source: TransactionEvent.event_type
     "trigger_reason": str | None,  # Why event was triggered
-                                   # Values: "Authorized", "CablePluggedIn", "ChargingStateChanged",
-                                   #         "MeterValuePeriodic", "StopAuthorized", etc.
-                                   # Default: None
-                                   # Source: TransactionEvent.trigger_reason
-
+    # Values: "Authorized", "CablePluggedIn", "ChargingStateChanged",
+    #         "MeterValuePeriodic", "StopAuthorized", etc.
+    # Default: None
+    # Source: TransactionEvent.trigger_reason
     "stopped_reason": str | None,  # Why charging stopped
-                                   # Values: "EVDisconnected", "Remote", "Local", etc.
-                                   # Default: None
-                                   # Source: TransactionEvent.transaction_info.stopped_reason
-
-    "sequence_number": int,      # Message sequence counter
-                                 # Default: 0
-                                 # Source: TransactionEvent.seq_no
-
-    "last_update": str | None,   # ISO timestamp of last update
-                                 # Default: None
-                                 # Source: TransactionEvent.timestamp
-
+    # Values: "EVDisconnected", "Remote", "Local", etc.
+    # Default: None
+    # Source: TransactionEvent.transaction_info.stopped_reason
+    "sequence_number": int,  # Message sequence counter
+    # Default: 0
+    # Source: TransactionEvent.seq_no
+    "last_update": str | None,  # ISO timestamp of last update
+    # Default: None
+    # Source: TransactionEvent.timestamp
     # ═══════════════════════════════════════════════════════════════════
     # AUTHORIZATION
     # ═══════════════════════════════════════════════════════════════════
-    "id_token": str | None,      # RFID token identifier
-                                 # Default: None
-                                 # Source: TransactionEvent.id_token.id_token
-
+    "id_token": str | None,  # RFID token identifier
+    # Default: None
+    # Source: TransactionEvent.id_token.id_token
     "id_token_type": str | None,  # Token type
-                                  # Values: "Central", "Local", "NoAuthorization"
-                                  # Default: None
-                                  # Source: TransactionEvent.id_token.type
-
+    # Values: "Central", "Local", "NoAuthorization"
+    # Default: None
+    # Source: TransactionEvent.id_token.type
     # ═══════════════════════════════════════════════════════════════════
     # POWER MEASUREMENTS (from TransactionEvent meter_value)
     # ═══════════════════════════════════════════════════════════════════
-    "power": float,              # Active power import (W)
-                                 # Default: 0.0
-                                 # Measurand: "Power.Active.Import"
-
+    "power": float,  # Active power import (W)
+    # Default: 0.0
+    # Measurand: "Power.Active.Import"
     "power_active_export": float | None,  # Active power export (W)
-                                          # Default: None
-                                          # Measurand: "Power.Active.Export"
-
+    # Default: None
+    # Measurand: "Power.Active.Export"
     "power_reactive_import": float | None,  # Reactive power import (VAr)
-                                            # Default: None
-                                            # Measurand: "Power.Reactive.Import"
-
+    # Default: None
+    # Measurand: "Power.Reactive.Import"
     "power_reactive_export": float | None,  # Reactive power export (VAr)
-                                            # Default: None
-                                            # Measurand: "Power.Reactive.Export"
-
+    # Default: None
+    # Measurand: "Power.Reactive.Export"
     "power_offered": float | None,  # Maximum power offered (W)
-                                    # Default: None
-                                    # Measurand: "Power.Offered"
-
+    # Default: None
+    # Measurand: "Power.Offered"
     "power_factor": float | None,  # Power factor (0.0-1.0)
-                                   # Default: None
-                                   # Measurand: "Power.Factor"
-
+    # Default: None
+    # Measurand: "Power.Factor"
     # ═══════════════════════════════════════════════════════════════════
     # ENERGY MEASUREMENTS (from TransactionEvent meter_value)
     # ═══════════════════════════════════════════════════════════════════
-    "energy_total": float,       # Total cumulative energy (kWh) - for Energy Dashboard
-                                 # Default: 0.0
-                                 # Calculated: energy_cumulative + last_session_energy
-                                 # Note: Never resets, accumulates across all sessions
-
+    "energy_total": float,  # Total cumulative energy (kWh) - for Energy Dashboard
+    # Default: 0.0
+    # Calculated: energy_cumulative + last_session_energy
+    # Note: Never resets, accumulates across all sessions
     "energy_cumulative": float,  # Cumulative energy from completed sessions (kWh)
-                                 # Default: 0.0
-                                 # Updated: When new session detected (energy drop)
-    
+    # Default: 0.0
+    # Updated: When new session detected (energy drop)
     "last_session_energy": float,  # Last seen session energy for session detection (kWh)
-                                   # Default: 0.0
-                                   # Used to detect session end and add to cumulative
-    
+    # Default: 0.0
+    # Used to detect session end and add to cumulative
     # Period-based energy tracking (auto-reset)
-    "energy_daily": float,       # Daily energy (kWh) - resets at midnight
-                                 # Default: 0.0
-    
-    "energy_weekly": float,      # Weekly energy (kWh) - resets Monday midnight
-                                 # Default: 0.0
-    
-    "energy_monthly": float,     # Monthly energy (kWh) - resets 1st of month
-                                 # Default: 0.0
-    
-    "energy_yearly": float,      # Yearly energy (kWh) - resets January 1st
-                                 # Default: 0.0
-    
+    "energy_daily": float,  # Daily energy (kWh) - resets at midnight
+    # Default: 0.0
+    "energy_weekly": float,  # Weekly energy (kWh) - resets Monday midnight
+    # Default: 0.0
+    "energy_monthly": float,  # Monthly energy (kWh) - resets 1st of month
+    # Default: 0.0
+    "energy_yearly": float,  # Yearly energy (kWh) - resets January 1st
+    # Default: 0.0
     # Reset timestamp tracking
-    "last_reset_daily": datetime | None,    # Last daily reset timestamp
-                                            # Default: None
-    
-    "last_reset_weekly": datetime | None,   # Last weekly reset timestamp
-                                             # Default: None
-    
+    "last_reset_daily": datetime | None,  # Last daily reset timestamp
+    # Default: None
+    "last_reset_weekly": datetime | None,  # Last weekly reset timestamp
+    # Default: None
     "last_reset_monthly": datetime | None,  # Last monthly reset timestamp
-                                             # Default: None
-    
-    "last_reset_yearly": datetime | None,   # Last yearly reset timestamp
-                                             # Default: None
-
+    # Default: None
+    "last_reset_yearly": datetime | None,  # Last yearly reset timestamp
+    # Default: None
     "energy_active_export": float | None,  # Energy exported (kWh)
-                                           # Default: None
-                                           # Measurand: "Energy.Active.Export.Register"
-
+    # Default: None
+    # Measurand: "Energy.Active.Export.Register"
     "energy_reactive_import": float | None,  # Reactive energy import (kVArh)
-                                             # Default: None
-                                             # Measurand: "Energy.Reactive.Import.Register"
-
+    # Default: None
+    # Measurand: "Energy.Reactive.Import.Register"
     "energy_reactive_export": float | None,  # Reactive energy export (kVArh)
-                                             # Default: None
-                                             # Measurand: "Energy.Reactive.Export.Register"
-
+    # Default: None
+    # Measurand: "Energy.Reactive.Export.Register"
     # ═══════════════════════════════════════════════════════════════════
     # CURRENT MEASUREMENTS (from TransactionEvent meter_value)
     # ═══════════════════════════════════════════════════════════════════
-    "current": float,            # Total/average current (A)
-                                 # Default: 0.0
-                                 # Measurand: "Current.Import" (no phase)
-
+    "current": float,  # Total/average current (A)
+    # Default: 0.0
+    # Measurand: "Current.Import" (no phase)
     "current_l1": float | None,  # Phase L1 current (A)
-                                 # Default: None
-                                 # Measurand: "Current.Import", phase="L1"
-
+    # Default: None
+    # Measurand: "Current.Import", phase="L1"
     "current_l2": float | None,  # Phase L2 current (A)
-                                 # Default: None
-                                 # Measurand: "Current.Import", phase="L2"
-
+    # Default: None
+    # Measurand: "Current.Import", phase="L2"
     "current_l3": float | None,  # Phase L3 current (A)
-                                 # Default: None
-                                 # Measurand: "Current.Import", phase="L3"
-
+    # Default: None
+    # Measurand: "Current.Import", phase="L3"
     # ═══════════════════════════════════════════════════════════════════
     # VOLTAGE MEASUREMENTS (from TransactionEvent meter_value)
     # ═══════════════════════════════════════════════════════════════════
-    "voltage": float,            # Average/total voltage (V)
-                                 # Default: 0.0
-                                 # Measurand: "Voltage" (no phase)
-
+    "voltage": float,  # Average/total voltage (V)
+    # Default: 0.0
+    # Measurand: "Voltage" (no phase)
     "voltage_l1": float | None,  # Phase L1 voltage (V)
-                                 # Default: None
-                                 # Measurand: "Voltage", phase="L1" or "L1-N"
-
+    # Default: None
+    # Measurand: "Voltage", phase="L1" or "L1-N"
     "voltage_l2": float | None,  # Phase L2 voltage (V)
-                                 # Default: None
-                                 # Measurand: "Voltage", phase="L2" or "L2-N"
-
+    # Default: None
+    # Measurand: "Voltage", phase="L2" or "L2-N"
     "voltage_l3": float | None,  # Phase L3 voltage (V)
-                                 # Default: None
-                                 # Measurand: "Voltage", phase="L3" or "L3-N"
-
+    # Default: None
+    # Measurand: "Voltage", phase="L3" or "L3-N"
     # ═══════════════════════════════════════════════════════════════════
     # OTHER MEASUREMENTS
     # ═══════════════════════════════════════════════════════════════════
-    "frequency": float | None,   # Grid frequency (Hz)
-                                 # Default: None
-                                 # Measurand: "Frequency"
-
+    "frequency": float | None,  # Grid frequency (Hz)
+    # Default: None
+    # Measurand: "Frequency"
     "temperature": float | None,  # Temperature (°C)
-                                  # Default: None
-                                  # Measurand: "Temperature"
-
-    "soc": float | None,         # State of Charge (%)
-                                 # Default: None
-                                 # Measurand: "SoC"
-
-    "phases_used": int,          # Number of phases in use
-                                 # Default: 1
-                                 # Source: TransactionEvent.number_of_phases_used
-
+    # Default: None
+    # Measurand: "Temperature"
+    "soc": float | None,  # State of Charge (%)
+    # Default: None
+    # Measurand: "SoC"
+    "phases_used": int,  # Number of phases in use
+    # Default: 1
+    # Source: TransactionEvent.number_of_phases_used
     # ═══════════════════════════════════════════════════════════════════
     # CONTEXT INFO (from TransactionEvent meter_value)
     # ═══════════════════════════════════════════════════════════════════
-    "context": str | None,       # Measurement context
-                                 # Values: "Sample.Periodic", "Transaction.Begin", etc.
-                                 # Default: None
-                                 # Source: sampled_value.context
-
-    "location": str | None,      # Measurement location
-                                 # Values: "Outlet", "Cable", "EV"
-                                 # Default: None
-                                 # Source: sampled_value.location
-
+    "context": str | None,  # Measurement context
+    # Values: "Sample.Periodic", "Transaction.Begin", etc.
+    # Default: None
+    # Source: sampled_value.context
+    "location": str | None,  # Measurement location
+    # Values: "Outlet", "Cable", "EV"
+    # Default: None
+    # Source: sampled_value.location
     # ═══════════════════════════════════════════════════════════════════
     # CONFIGURABLE SETTINGS
     # ═══════════════════════════════════════════════════════════════════
-    "led_brightness": int,       # LED brightness (0-100%)
-                                 # Default: 46 (from wallbox capabilities report)
-
-    "current_limit": float,      # Current limit set by user (A)
-                                 # Default: max_current from config
-                                 # Set via: async_set_current_limit()
+    "led_brightness": int,  # LED brightness (0-100%)
+    # Default: 46 (from wallbox capabilities report)
+    "current_limit": float,  # Current limit set by user (A)
+    # Default: max_current from config
+    # Set via: async_set_current_limit()
 }
 ```
 
@@ -256,35 +207,30 @@ Configuration stored in `entry.data` after config flow. Defined in `config_flow.
 
 ```python
 entry.data: dict[str, Any] = {
-    "port": int,                # WebSocket server port
-                                # Default: 9000
-                                # Validation: 1-65535
-                                # Constant: CONF_PORT
-
-    "ssl_cert": str,            # Path to SSL certificate file
-                                # Default: "/ssl/fullchain.pem"
-                                # Validation: File must exist
-                                # Constant: CONF_SSL_CERT
-
-    "ssl_key": str,             # Path to SSL private key file
-                                # Default: "/ssl/privkey.pem"
-                                # Validation: File must exist
-                                # Constant: CONF_SSL_KEY
-
-    "charge_point_id": str,     # Wallbox identifier
-                                # Required, no default
-                                # Example: "DE*BMW*ETEST1234567890AB"
-                                # Constant: CONF_CHARGE_POINT_ID
-
-    "rfid_token": str,          # RFID token for authorization
-                                # Optional, default: ""
-                                # Used in RequestStartTransaction
-                                # Constant: CONF_RFID_TOKEN
-
-    "max_current": int,         # Maximum allowed current (A)
-                                # Default: 32
-                                # Validation: 6-32
-                                # Constant: CONF_MAX_CURRENT
+    "port": int,  # WebSocket server port
+    # Default: 9000
+    # Validation: 1-65535
+    # Constant: CONF_PORT
+    "ssl_cert": str,  # Path to SSL certificate file
+    # Default: "/ssl/fullchain.pem"
+    # Validation: File must exist
+    # Constant: CONF_SSL_CERT
+    "ssl_key": str,  # Path to SSL private key file
+    # Default: "/ssl/privkey.pem"
+    # Validation: File must exist
+    # Constant: CONF_SSL_KEY
+    "charge_point_id": str,  # Wallbox identifier
+    # Required, no default
+    # Example: "DE*BMW*ETEST1234567890AB"
+    # Constant: CONF_CHARGE_POINT_ID
+    "rfid_token": str,  # RFID token for authorization
+    # Optional, default: ""
+    # Used in RequestStartTransaction
+    # Constant: CONF_RFID_TOKEN
+    "max_current": int,  # Maximum allowed current (A)
+    # Default: 32
+    # Validation: 6-32
+    # Constant: CONF_MAX_CURRENT
 }
 ```
 
@@ -292,16 +238,18 @@ entry.data: dict[str, Any] = {
 
 ```python
 # config_flow.py
-STEP_USER_DATA_SCHEMA = vol.Schema({
-    vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
-    vol.Required(CONF_SSL_CERT, default="/ssl/fullchain.pem"): str,
-    vol.Required(CONF_SSL_KEY, default="/ssl/privkey.pem"): str,
-    vol.Required(CONF_CHARGE_POINT_ID): str,
-    vol.Optional(CONF_RFID_TOKEN, default=""): str,
-    vol.Optional(CONF_MAX_CURRENT, default=DEFAULT_MAX_CURRENT): vol.All(
-        vol.Coerce(int), vol.Range(min=6, max=32)
-    ),
-})
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Required(CONF_SSL_CERT, default="/ssl/fullchain.pem"): str,
+        vol.Required(CONF_SSL_KEY, default="/ssl/privkey.pem"): str,
+        vol.Required(CONF_CHARGE_POINT_ID): str,
+        vol.Optional(CONF_RFID_TOKEN, default=""): str,
+        vol.Optional(CONF_MAX_CURRENT, default=DEFAULT_MAX_CURRENT): vol.All(
+            vol.Coerce(int), vol.Range(min=6, max=32)
+        ),
+    }
+)
 ```
 
 ---
@@ -317,31 +265,32 @@ The main data source for meter values and charging state.
 # Location: coordinator.py:110-230
 
 TransactionEvent = {
-    "event_type": str,           # "Started" | "Updated" | "Ended"
-    "timestamp": str,            # ISO 8601 timestamp
-    "trigger_reason": str,       # "Authorized" | "CablePluggedIn" | "MeterValuePeriodic" | ...
-    "seq_no": int,               # Sequence number
+    "event_type": str,  # "Started" | "Updated" | "Ended"
+    "timestamp": str,  # ISO 8601 timestamp
+    "trigger_reason": str,  # "Authorized" | "CablePluggedIn" | "MeterValuePeriodic" | ...
+    "seq_no": int,  # Sequence number
     "transaction_info": {
-        "transaction_id": str,   # UUID of transaction
-        "charging_state": str,   # "Charging" | "SuspendedEVSE" | "SuspendedEV" | "EVConnected" | "Idle"
+        "transaction_id": str,  # UUID of transaction
+        "charging_state": str,  # "Charging" | "SuspendedEVSE" | "SuspendedEV" | "EVConnected" | "Idle"
         "stopped_reason": str | None,  # "EVDisconnected" | "Remote" | ...
     },
-    "id_token": {                # Optional
-        "id_token": str,         # RFID token value
-        "type": str,             # "Central" | "Local" | "NoAuthorization"
+    "id_token": {  # Optional
+        "id_token": str,  # RFID token value
+        "type": str,  # "Central" | "Local" | "NoAuthorization"
     },
-    "meter_value": [             # Optional, list of meter value groups
+    "meter_value": [  # Optional, list of meter value groups
         {
             "timestamp": str,
             "sampled_value": [
                 {
-                    "value": str,           # Numeric value as string
-                    "measurand": str,       # "Power.Active.Import" | "Voltage" | "Current.Import" | ...
-                    "phase": str | None,    # "L1" | "L2" | "L3" | "L1-N" | None
-                    "context": str | None,  # "Sample.Periodic" | "Transaction.Begin" | ...
-                    "location": str | None, # "Outlet" | "Cable" | "EV"
+                    "value": str,  # Numeric value as string
+                    "measurand": str,  # "Power.Active.Import" | "Voltage" | "Current.Import" | ...
+                    "phase": str | None,  # "L1" | "L2" | "L3" | "L1-N" | None
+                    "context": str
+                    | None,  # "Sample.Periodic" | "Transaction.Begin" | ...
+                    "location": str | None,  # "Outlet" | "Cable" | "EV"
                 }
-            ]
+            ],
         }
     ],
     "number_of_phases_used": int | None,  # 1, 2, or 3
@@ -357,10 +306,10 @@ Connector status updates.
 # Location: coordinator.py:79-97
 
 StatusNotification = {
-    "timestamp": str,            # ISO 8601 timestamp
-    "connector_status": str,     # "Available" | "Occupied" | "Reserved" | "Unavailable" | "Faulted"
-    "evse_id": int,              # EVSE identifier (1)
-    "connector_id": int,         # Connector identifier (1)
+    "timestamp": str,  # ISO 8601 timestamp
+    "connector_status": str,  # "Available" | "Occupied" | "Reserved" | "Unavailable" | "Faulted"
+    "evse_id": int,  # EVSE identifier (1)
+    "connector_id": int,  # Connector identifier (1)
 }
 ```
 
@@ -374,12 +323,12 @@ Device information on startup.
 
 BootNotification = {
     "charging_station": {
-        "model": str,            # e.g., "EIAW-E22KTSE6B04"
-        "vendor_name": str,      # e.g., "BMW"
-        "serial_number": str,    # Wallbox serial
-        "firmware_version": str, # Firmware version
+        "model": str,  # e.g., "EIAW-E22KTSE6B04"
+        "vendor_name": str,  # e.g., "BMW"
+        "serial_number": str,  # Wallbox serial
+        "firmware_version": str,  # Firmware version
     },
-    "reason": str,               # "PowerUp" | "RemoteReset" | ...
+    "reason": str,  # "PowerUp" | "RemoteReset" | ...
 }
 ```
 
@@ -407,23 +356,27 @@ Control charging current.
 # Location: coordinator.py:759-832
 
 SetChargingProfile = {
-    "evse_id": int,              # Always 1
+    "evse_id": int,  # Always 1
     "charging_profile": {
-        "id": int,               # Profile ID (999)
-        "stack_level": int,      # Priority (1)
+        "id": int,  # Profile ID (999)
+        "stack_level": int,  # Priority (1)
         "charging_profile_purpose": str,  # "TxProfile"
-        "charging_profile_kind": str,     # "Absolute"
-        "charging_schedule": [{
-            "id": int,
-            "start_schedule": str,        # ISO timestamp
-            "charging_rate_unit": str,    # "A" (Amps)
-            "charging_schedule_period": [{
-                "start_period": int,      # 0 (immediate)
-                "limit": float,           # Current in Amps (0 = pause, 32 = full)
-            }]
-        }],
-        "transaction_id": str,   # REQUIRED - active transaction ID
-    }
+        "charging_profile_kind": str,  # "Absolute"
+        "charging_schedule": [
+            {
+                "id": int,
+                "start_schedule": str,  # ISO timestamp
+                "charging_rate_unit": str,  # "A" (Amps)
+                "charging_schedule_period": [
+                    {
+                        "start_period": int,  # 0 (immediate)
+                        "limit": float,  # Current in Amps (0 = pause, 32 = full)
+                    }
+                ],
+            }
+        ],
+        "transaction_id": str,  # REQUIRED - active transaction ID
+    },
 }
 ```
 
@@ -437,11 +390,11 @@ Start a new charging session.
 
 RequestStartTransaction = {
     "id_token": {
-        "id_token": str,         # RFID token from config
-        "type": str,             # "Local"
+        "id_token": str,  # RFID token from config
+        "type": str,  # "Local"
     },
-    "remote_start_id": int,      # Unique ID (timestamp)
-    "evse_id": int,              # Always 1
+    "remote_start_id": int,  # Unique ID (timestamp)
+    "evse_id": int,  # Always 1
 }
 ```
 
@@ -454,16 +407,18 @@ Configure wallbox settings.
 # Location: coordinator.py:834-886
 
 SetVariables = {
-    "set_variable_data": [{
-        "attribute_type": str,   # "Actual"
-        "attribute_value": str,  # Value as string
-        "component": {
-            "name": str,         # "ChargingStation"
-        },
-        "variable": {
-            "name": str,         # "StatusLedBrightness"
+    "set_variable_data": [
+        {
+            "attribute_type": str,  # "Actual"
+            "attribute_value": str,  # Value as string
+            "component": {
+                "name": str,  # "ChargingStation"
+            },
+            "variable": {
+                "name": str,  # "StatusLedBrightness"
+            },
         }
-    }]
+    ]
 }
 ```
 
@@ -476,7 +431,7 @@ Reboot the wallbox.
 # Location: coordinator.py:471-524
 
 Reset = {
-    "type": str,                 # "Immediate" | "OnIdle"
+    "type": str,  # "Immediate" | "OnIdle"
 }
 ```
 
@@ -488,10 +443,10 @@ Reset = {
 
 ```python
 extra_state_attributes = {
-    "charging_state": str,       # Raw OCPP charging state
-    "power_w": float,            # Current power in watts
+    "charging_state": str,  # Raw OCPP charging state
+    "power_w": float,  # Current power in watts
     "transaction_id": str | None,  # Active transaction
-    "wallbox_connected": bool,   # OCPP connection status
+    "wallbox_connected": bool,  # OCPP connection status
 }
 ```
 
@@ -499,7 +454,7 @@ extra_state_attributes = {
 
 ```python
 extra_state_attributes = {
-    "ocpp_state": str,           # Raw OCPP state value
+    "ocpp_state": str,  # Raw OCPP state value
     "transaction_id": str | None,  # Active transaction
 }
 ```
@@ -508,7 +463,7 @@ extra_state_attributes = {
 
 ```python
 extra_state_attributes = {
-    "type": str,                 # "Central" | "Local" | "Unknown"
+    "type": str,  # "Central" | "Local" | "Unknown"
 }
 ```
 
@@ -536,9 +491,9 @@ Populated from BootNotification.
 
 ```python
 coordinator.device_info: dict[str, str] = {
-    "model": str,                # From charging_station.model
-    "vendor": str,               # From charging_station.vendor_name
-    "serial_number": str,        # From charging_station.serial_number
-    "firmware_version": str,     # From charging_station.firmware_version
+    "model": str,  # From charging_station.model
+    "vendor": str,  # From charging_station.vendor_name
+    "serial_number": str,  # From charging_station.serial_number
+    "firmware_version": str,  # From charging_station.firmware_version
 }
 ```

--- a/custom_components/bmw_wallbox/docs/ENTITIES.md
+++ b/custom_components/bmw_wallbox/docs/ENTITIES.md
@@ -133,23 +133,25 @@ class BMWWallboxSensorBase(CoordinatorEntity, SensorEntity):
         self,
         coordinator: BMWWallboxCoordinator,
         entry: ConfigEntry,
-        sensor_type: str,    # Unique suffix for entity ID
-        name: str,           # Display name
+        sensor_type: str,  # Unique suffix for entity ID
+        name: str,  # Display name
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
-        
+
         # Unique ID: {config_entry_id}_{sensor_type}
         self._attr_unique_id = f"{entry.entry_id}_{sensor_type}"
-        
+
         # Display name
         self._attr_name = name
-        
+
         # Device grouping - REQUIRED for all entities
         self._attr_device_info = {
             "identifiers": {(DOMAIN, entry.data["charge_point_id"])},
             "name": "BMW Wallbox",
-            "manufacturer": coordinator.device_info.get("vendor", "BMW (Delta Electronics)"),
+            "manufacturer": coordinator.device_info.get(
+                "vendor", "BMW (Delta Electronics)"
+            ),
             "model": coordinator.device_info.get("model", "EIAW-E22KTSE6B04"),
             "sw_version": coordinator.device_info.get("firmware_version"),
             "serial_number": coordinator.device_info.get("serial_number"),
@@ -211,15 +213,16 @@ elif measurand == "New.Metric.Name":
 ```python
 # sensor.py - add new sensor class
 
+
 class BMWWallboxNewMetricSensor(BMWWallboxSensorBase):
     """Sensor for new metric."""
 
     def __init__(self, coordinator: BMWWallboxCoordinator, entry: ConfigEntry) -> None:
         super().__init__(
-            coordinator, 
-            entry, 
+            coordinator,
+            entry,
             SENSOR_NEW_METRIC,  # From const.py
-            "New Metric"        # Display name
+            "New Metric",  # Display name
         )
         # Set sensor attributes
         self._attr_device_class = SensorDeviceClass.POWER  # or appropriate class
@@ -244,11 +247,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: BMWWallboxCoordinator = hass.data[DOMAIN][entry.entry_id]
-    
-    async_add_entities([
-        # ... existing sensors ...
-        BMWWallboxNewMetricSensor(coordinator, entry),  # Add new sensor
-    ])
+
+    async_add_entities(
+        [
+            # ... existing sensors ...
+            BMWWallboxNewMetricSensor(coordinator, entry),  # Add new sensor
+        ]
+    )
 ```
 
 ---
@@ -277,6 +282,7 @@ self.data: dict[str, Any] = {
 ```python
 # binary_sensor.py
 
+
 class BMWWallboxNewStateBinarySensor(BMWWallboxBinarySensorBase):
     """Binary sensor for new state."""
 
@@ -295,10 +301,12 @@ class BMWWallboxNewStateBinarySensor(BMWWallboxBinarySensorBase):
 
 ```python
 # binary_sensor.py - in async_setup_entry()
-async_add_entities([
-    # ... existing ...
-    BMWWallboxNewStateBinarySensor(coordinator, entry),
-])
+async_add_entities(
+    [
+        # ... existing ...
+        BMWWallboxNewStateBinarySensor(coordinator, entry),
+    ]
+)
 ```
 
 ---
@@ -320,11 +328,10 @@ async def async_new_action(self) -> dict:
     """Perform new action."""
     if not self.charge_point:
         return {"success": False, "message": "Not connected"}
-    
+
     try:
         response = await asyncio.wait_for(
-            self.charge_point.call(call.SomeCommand(...)),
-            timeout=15.0
+            self.charge_point.call(call.SomeCommand(...)), timeout=15.0
         )
         return {"success": True, "message": "Done"}
     except Exception as err:
@@ -336,10 +343,16 @@ async def async_new_action(self) -> dict:
 ```python
 # button.py
 
+
 class BMWWallboxNewActionButton(BMWWallboxButtonBase):
     """Button for new action."""
 
-    def __init__(self, coordinator: BMWWallboxCoordinator, entry: ConfigEntry, hass: HomeAssistant) -> None:
+    def __init__(
+        self,
+        coordinator: BMWWallboxCoordinator,
+        entry: ConfigEntry,
+        hass: HomeAssistant,
+    ) -> None:
         super().__init__(coordinator, entry, hass, BUTTON_NEW_ACTION)
         self._attr_name = "New Action"
         self._base_icon = "mdi:gesture-tap"
@@ -361,10 +374,12 @@ class BMWWallboxNewActionButton(BMWWallboxButtonBase):
 
 ```python
 # button.py - in async_setup_entry()
-async_add_entities([
-    # ... existing ...
-    BMWWallboxNewActionButton(coordinator, entry, hass),
-])
+async_add_entities(
+    [
+        # ... existing ...
+        BMWWallboxNewActionButton(coordinator, entry, hass),
+    ]
+)
 ```
 
 ---
@@ -386,12 +401,11 @@ async def async_set_new_setting(self, value: int) -> bool:
     """Set new setting value."""
     if not self.charge_point:
         return False
-    
+
     try:
         # Send OCPP command
         response = await asyncio.wait_for(
-            self.charge_point.call(call.SetVariables(...)),
-            timeout=15.0
+            self.charge_point.call(call.SetVariables(...)), timeout=15.0
         )
         return response.status == "Accepted"
     except Exception:
@@ -402,6 +416,7 @@ async def async_set_new_setting(self, value: int) -> bool:
 
 ```python
 # number.py
+
 
 class BMWWallboxNewSettingNumber(CoordinatorEntity, NumberEntity):
     """Number entity for new setting."""
@@ -440,10 +455,12 @@ class BMWWallboxNewSettingNumber(CoordinatorEntity, NumberEntity):
 
 ```python
 # number.py - in async_setup_entry()
-async_add_entities([
-    # ... existing ...
-    BMWWallboxNewSettingNumber(coordinator, entry),
-])
+async_add_entities(
+    [
+        # ... existing ...
+        BMWWallboxNewSettingNumber(coordinator, entry),
+    ]
+)
 ```
 
 ---
@@ -461,6 +478,7 @@ SWITCH_NEW_TOGGLE: Final = "new_toggle"
 
 ```python
 # switch.py
+
 
 class BMWWallboxNewToggleSwitch(CoordinatorEntity, SwitchEntity):
     """Switch entity for new toggle."""
@@ -497,7 +515,6 @@ Some entities change icon based on state. Example from `sensor.py`:
 
 ```python
 class BMWWallboxStatusSensor(BMWWallboxSensorBase):
-    
     @property
     def icon(self) -> str:
         """Return icon based on status."""
@@ -525,7 +542,6 @@ Add additional data to entities via `extra_state_attributes`:
 
 ```python
 class BMWWallboxStateSensor(BMWWallboxSensorBase):
-    
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional attributes."""
@@ -543,11 +559,10 @@ Control when entities are available:
 
 ```python
 class BMWWallboxCurrentLimitNumber(CoordinatorEntity, NumberEntity):
-    
     @property
     def available(self) -> bool:
         """Return True if entity is available.
-        
+
         Current limit only works when there's an active transaction.
         """
         return (

--- a/custom_components/bmw_wallbox/docs/OCPP_HANDLERS.md
+++ b/custom_components/bmw_wallbox/docs/OCPP_HANDLERS.md
@@ -9,9 +9,10 @@ from ocpp.routing import on
 from ocpp.v201 import ChargePoint as cp
 from ocpp.v201 import call, call_result
 
+
 class WallboxChargePoint(cp):
     """ChargePoint handler for the BMW wallbox."""
-    
+
     @on("MessageName")
     async def on_message_name(self, param1, param2, **kwargs):
         # Handle incoming message
@@ -63,12 +64,13 @@ The `@on("MessageName")` decorator from `ocpp.routing` registers a method as a h
 ```python
 from ocpp.routing import on
 
+
 @on("BootNotification")  # Message type to handle
 async def on_boot_notification(
     self,
-    charging_station,    # Required parameter from message
-    reason,              # Required parameter from message
-    **kwargs             # Catch any additional optional parameters
+    charging_station,  # Required parameter from message
+    reason,  # Required parameter from message
+    **kwargs,  # Catch any additional optional parameters
 ):
     # Process message
     # Return response
@@ -161,25 +163,27 @@ async def on_status_notification(
     """Handle StatusNotification."""
     _LOGGER.debug(
         "Status: EVSE=%s, Connector=%s, Status=%s",
-        evse_id, connector_id, connector_status,
+        evse_id,
+        connector_id,
+        connector_status,
     )
-    
+
     # Update coordinator data
     self.coordinator.data["connector_status"] = connector_status
     self.coordinator.data["evse_id"] = evse_id
     self.coordinator.data["connector_id"] = connector_id
-    
+
     # Trigger entity updates
     self.coordinator.async_set_updated_data(self.coordinator.data)
-    
+
     return call_result.StatusNotification()
 ```
 
 **Input Schema:**
 ```python
 {
-    "timestamp": str,           # ISO 8601
-    "connector_status": str,    # "Available", "Occupied", "Reserved", etc.
+    "timestamp": str,  # ISO 8601
+    "connector_status": str,  # "Available", "Occupied", "Reserved", etc.
     "evse_id": int,
     "connector_id": int,
 }
@@ -253,54 +257,58 @@ flowchart TB
 @on("TransactionEvent")
 async def on_transaction_event(
     self,
-    event_type,          # "Started", "Updated", "Ended"
-    timestamp,           # ISO 8601
-    trigger_reason,      # "Authorized", "MeterValuePeriodic", etc.
-    seq_no,              # Sequence number
-    transaction_info,    # Contains transaction_id, charging_state
-    **kwargs,            # Contains id_token, meter_value, etc.
+    event_type,  # "Started", "Updated", "Ended"
+    timestamp,  # ISO 8601
+    trigger_reason,  # "Authorized", "MeterValuePeriodic", etc.
+    seq_no,  # Sequence number
+    transaction_info,  # Contains transaction_id, charging_state
+    **kwargs,  # Contains id_token, meter_value, etc.
 ):
     """Handle TransactionEvent - contains all the sensor data!"""
     _LOGGER.debug(
         "Transaction Event: type=%s, reason=%s, seq=%s",
-        event_type, trigger_reason, seq_no,
+        event_type,
+        trigger_reason,
+        seq_no,
     )
-    
+
     # Extract transaction ID
     self.current_transaction_id = transaction_info.get("transaction_id")
     self.coordinator.current_transaction_id = self.current_transaction_id
-    
+
     # Update basic transaction info
-    self.coordinator.data.update({
-        "transaction_id": self.current_transaction_id,
-        "charging_state": transaction_info.get("charging_state", "Unknown"),
-        "event_type": event_type,
-        "trigger_reason": trigger_reason,
-        "sequence_number": seq_no,
-        "last_update": timestamp,
-        "stopped_reason": transaction_info.get("stopped_reason"),
-    })
-    
+    self.coordinator.data.update(
+        {
+            "transaction_id": self.current_transaction_id,
+            "charging_state": transaction_info.get("charging_state", "Unknown"),
+            "event_type": event_type,
+            "trigger_reason": trigger_reason,
+            "sequence_number": seq_no,
+            "last_update": timestamp,
+            "stopped_reason": transaction_info.get("stopped_reason"),
+        }
+    )
+
     # Extract ID token (RFID)
     id_token = kwargs.get("id_token", {})
     if id_token:
         self.coordinator.data["id_token"] = id_token.get("id_token")
         self.coordinator.data["id_token_type"] = id_token.get("type")
-    
+
     # Extract meter values
     meter_value = kwargs.get("meter_value", [])
     if meter_value:
         for mv in meter_value:
             for sample in mv.get("sampled_value", []):
                 self._process_sampled_value(sample)
-    
+
     # Extract phases
     if "number_of_phases_used" in kwargs:
         self.coordinator.data["phases_used"] = kwargs["number_of_phases_used"]
-    
+
     # Trigger entity updates
     self.coordinator.async_set_updated_data(self.coordinator.data)
-    
+
     return call_result.TransactionEvent()
 ```
 
@@ -342,18 +350,18 @@ if meter_value:
         for sample in mv.get("sampled_value", []):
             measurand = sample.get("measurand")
             value = sample.get("value")
-            phase = sample.get("phase")       # "L1", "L2", "L3", or None
-            context = sample.get("context")   # "Sample.Periodic", etc.
-            location = sample.get("location") # "Outlet", "Cable", "EV"
-            
+            phase = sample.get("phase")  # "L1", "L2", "L3", or None
+            context = sample.get("context")  # "Sample.Periodic", etc.
+            location = sample.get("location")  # "Outlet", "Cable", "EV"
+
             # Power measurements
             if measurand == "Power.Active.Import":
                 self.coordinator.data["power"] = float(value)
-            
+
             # Energy measurements
             elif measurand == "Energy.Active.Import.Register":
                 self.coordinator.data["energy_total"] = float(value) / 1000  # Wh to kWh
-            
+
             # Current measurements (per phase)
             elif measurand == "Current.Import":
                 if phase == "L1":
@@ -364,7 +372,7 @@ if meter_value:
                     self.coordinator.data["current_l3"] = float(value)
                 else:
                     self.coordinator.data["current"] = float(value)
-            
+
             # Voltage measurements (per phase)
             elif measurand == "Voltage":
                 if phase in ("L1", "L1-N"):
@@ -375,7 +383,7 @@ if meter_value:
                     self.coordinator.data["voltage_l3"] = float(value)
                 else:
                     self.coordinator.data["voltage"] = float(value)
-            
+
             # Other measurements
             elif measurand == "Frequency":
                 self.coordinator.data["frequency"] = float(value)
@@ -415,7 +423,9 @@ if meter_value:
 
 ```python
 @on("NotifyReport")
-async def on_notify_report(self, request_id, seq_no, generated_at, report_data, **kwargs):
+async def on_notify_report(
+    self, request_id, seq_no, generated_at, report_data, **kwargs
+):
     """Handle NotifyReport - configuration data."""
     _LOGGER.debug("Notify Report: request_id=%s, seq=%s", request_id, seq_no)
     return call_result.NotifyReport()
@@ -458,15 +468,16 @@ flowchart TD
 ```python
 # coordinator.py - command pattern
 
+
 async def async_some_command(self) -> dict:
     """Send command to wallbox."""
     result = {"success": False, "message": ""}
-    
+
     # Check connection
     if not self.charge_point:
         result["message"] = "Wallbox not connected"
         return result
-    
+
     try:
         # Send command with timeout
         response = await asyncio.wait_for(
@@ -476,18 +487,18 @@ async def async_some_command(self) -> dict:
                     param2=value2,
                 )
             ),
-            timeout=15.0  # 15 second timeout
+            timeout=15.0,  # 15 second timeout
         )
-        
+
         # Check response
         if response.status == ExpectedStatus.accepted:
             result["success"] = True
             result["message"] = "Command accepted"
         else:
             result["message"] = f"Rejected: {response.status}"
-        
+
         return result
-        
+
     except asyncio.TimeoutError:
         result["message"] = "Command timed out"
         _LOGGER.error("Command timed out!")
@@ -525,7 +536,7 @@ response = await asyncio.wait_for(
             evse_id=1,
         )
     ),
-    timeout=15.0
+    timeout=15.0,
 )
 
 if response.status == RequestStartStopStatusEnumType.accepted:
@@ -581,7 +592,7 @@ schedule = ChargingScheduleType(
     charging_schedule_period=[
         ChargingSchedulePeriodType(
             start_period=0,
-            limit=32.0  # Amps (0 = pause, 32 = full)
+            limit=32.0,  # Amps (0 = pause, 32 = full)
         )
     ],
 )
@@ -600,7 +611,7 @@ response = await asyncio.wait_for(
     self.charge_point.call(
         call.SetChargingProfile(evse_id=1, charging_profile=profile)
     ),
-    timeout=15.0
+    timeout=15.0,
 )
 
 if response.status == "Accepted":
@@ -634,10 +645,7 @@ set_var = SetVariableDataType(
 )
 
 response = await asyncio.wait_for(
-    self.charge_point.call(
-        call.SetVariables(set_variable_data=[set_var])
-    ),
-    timeout=15.0
+    self.charge_point.call(call.SetVariables(set_variable_data=[set_var])), timeout=15.0
 )
 
 # Check result
@@ -661,10 +669,7 @@ if response.set_variable_result:
 from ocpp.v201.enums import ResetEnumType, ResetStatusEnumType
 
 response = await asyncio.wait_for(
-    self.charge_point.call(
-        call.Reset(type=ResetEnumType.immediate)
-    ),
-    timeout=15.0
+    self.charge_point.call(call.Reset(type=ResetEnumType.immediate)), timeout=15.0
 )
 
 if response.status == ResetStatusEnumType.accepted:
@@ -682,6 +687,7 @@ if response.status == ResetStatusEnumType.accepted:
 ```python
 # coordinator.py - in WallboxChargePoint class
 
+
 @on("NewMessageType")
 async def on_new_message_type(
     self,
@@ -691,13 +697,13 @@ async def on_new_message_type(
 ):
     """Handle NewMessageType from wallbox."""
     _LOGGER.debug("NewMessageType received: %s, %s", required_param1, required_param2)
-    
+
     # Extract data and update coordinator
     self.coordinator.data["new_field"] = required_param1
-    
+
     # Trigger entity updates
     self.coordinator.async_set_updated_data(self.coordinator.data)
-    
+
     # Return response
     return call_result.NewMessageType(
         response_param="value",
@@ -740,16 +746,17 @@ flowchart TB
 ```python
 # coordinator.py - in BMWWallboxCoordinator class
 
+
 async def async_new_command(self, param: int) -> dict:
     """Send new command to wallbox."""
     result = {"success": False, "message": ""}
-    
+
     if not self.charge_point:
         result["message"] = "Wallbox not connected"
         return result
-    
+
     _LOGGER.info("Sending NewCommand with param=%s", param)
-    
+
     try:
         response = await asyncio.wait_for(
             self.charge_point.call(
@@ -757,17 +764,17 @@ async def async_new_command(self, param: int) -> dict:
                     param=param,
                 )
             ),
-            timeout=15.0
+            timeout=15.0,
         )
-        
+
         if response.status == "Accepted":
             result["success"] = True
             result["message"] = "Command accepted"
         else:
             result["message"] = f"Rejected: {response.status}"
-        
+
         return result
-        
+
     except asyncio.TimeoutError:
         result["message"] = "Command timed out"
         return result

--- a/custom_components/bmw_wallbox/docs/PATTERNS.md
+++ b/custom_components/bmw_wallbox/docs/PATTERNS.md
@@ -216,13 +216,12 @@ async def async_command(self) -> dict:
         "message": "",
         "action": "failed",
     }
-    
+
     try:
         response = await asyncio.wait_for(
-            self.charge_point.call(call.Command(...)),
-            timeout=15.0
+            self.charge_point.call(call.Command(...)), timeout=15.0
         )
-        
+
         if response.status == "Accepted":
             result["success"] = True
             result["message"] = "Command accepted"
@@ -230,9 +229,9 @@ async def async_command(self) -> dict:
         else:
             result["message"] = f"Rejected: {response.status}"
             result["action"] = "rejected"
-        
+
         return result
-        
+
     except asyncio.TimeoutError:
         result["message"] = "Command timed out"
         _LOGGER.error("Command timed out!")
@@ -314,9 +313,7 @@ self._attr_device_info = {
 ```python
 # ❌ WRONG: Causes stuck transaction states
 response = await self.charge_point.call(
-    call.RequestStopTransaction(
-        transaction_id=self.current_transaction_id
-    )
+    call.RequestStopTransaction(transaction_id=self.current_transaction_id)
 )
 # After this, wallbox enters "Finishing" state - cannot restart!
 
@@ -409,8 +406,10 @@ class BMWWallboxPowerSensor(BMWWallboxSensorBase):
 # ❌ WRONG: Blocking call
 async def async_some_method(self):
     import time
+
     time.sleep(5)  # Blocks the event loop!
-    
+
+
 # ✅ CORRECT: Async sleep
 async def async_some_method(self):
     await asyncio.sleep(5)  # Non-blocking
@@ -428,8 +427,7 @@ response = await self.charge_point.call(call.Command(...))
 
 # ✅ CORRECT: Always use timeout
 response = await asyncio.wait_for(
-    self.charge_point.call(call.Command(...)),
-    timeout=15.0
+    self.charge_point.call(call.Command(...)), timeout=15.0
 )
 ```
 
@@ -446,8 +444,7 @@ await self.charge_point.call(call.SetChargingProfile(...))
 
 # ✅ CORRECT: Check result
 response = await asyncio.wait_for(
-    self.charge_point.call(call.SetChargingProfile(...)),
-    timeout=15.0
+    self.charge_point.call(call.SetChargingProfile(...)), timeout=15.0
 )
 if response.status != "Accepted":
     _LOGGER.warning("Command rejected: %s", response.status)
@@ -466,6 +463,7 @@ self._attr_unique_id = f"{entry.entry_id}_power"  # "power" is magic string
 
 # ✅ CORRECT: Use constants
 from .const import SENSOR_POWER
+
 self._attr_unique_id = f"{entry.entry_id}_{SENSOR_POWER}"
 ```
 

--- a/custom_components/bmw_wallbox/docs/TESTING.md
+++ b/custom_components/bmw_wallbox/docs/TESTING.md
@@ -160,16 +160,17 @@ def mock_wallbox_charge_point():
 ```python
 from custom_components.bmw_wallbox.sensor import BMWWallboxPowerSensor
 
+
 async def test_power_sensor(hass, mock_coordinator, mock_config_entry):
     """Test power sensor returns correct value."""
     sensor = BMWWallboxPowerSensor(mock_coordinator, mock_config_entry)
-    
+
     # Test value
     assert sensor.native_value == 7000.0
-    
+
     # Test unit
     assert sensor.native_unit_of_measurement == "W"
-    
+
     # Test device class
     assert sensor.device_class == "power"
 ```
@@ -179,10 +180,11 @@ async def test_power_sensor(hass, mock_coordinator, mock_config_entry):
 ```python
 from custom_components.bmw_wallbox.sensor import BMWWallboxStateSensor
 
+
 async def test_state_sensor_attributes(hass, mock_coordinator, mock_config_entry):
     """Test state sensor extra attributes."""
     sensor = BMWWallboxStateSensor(mock_coordinator, mock_config_entry)
-    
+
     attrs = sensor.extra_state_attributes
     assert attrs["evse_id"] == 1
     assert attrs["connector_id"] == 1
@@ -208,14 +210,16 @@ async def test_sensor_updates_with_data(hass, mock_coordinator, mock_config_entr
 ### Test Sensor Availability
 
 ```python
-async def test_sensor_unavailable_when_disconnected(hass, mock_coordinator, mock_config_entry):
+async def test_sensor_unavailable_when_disconnected(
+    hass, mock_coordinator, mock_config_entry
+):
     """Test sensor shows unavailable when disconnected."""
     sensor = BMWWallboxPowerSensor(mock_coordinator, mock_config_entry)
-    
+
     # Connected - has value
     mock_coordinator.data["connected"] = True
     assert sensor.native_value == 7000.0
-    
+
     # Disconnected - no value
     mock_coordinator.data["connected"] = False
     mock_coordinator.data["power"] = None
@@ -233,17 +237,18 @@ async def test_sensor_unavailable_when_disconnected(hass, mock_coordinator, mock
 ```python
 from custom_components.bmw_wallbox.button import BMWWallboxStartButton
 
+
 async def test_start_button(hass, mock_coordinator, mock_config_entry):
     """Test start charging button."""
     button = BMWWallboxStartButton(mock_coordinator, mock_config_entry, hass)
-    
+
     # Test properties
     assert button.name == "Start Charging"
     assert button._base_icon == "mdi:play"
-    
+
     # Test press
     await button.async_press()
-    
+
     # Verify coordinator method was called
     mock_coordinator.async_start_charging.assert_called_once()
 ```
@@ -273,16 +278,17 @@ async def test_button_loading_state(hass, mock_coordinator, mock_config_entry):
 ```python
 from custom_components.bmw_wallbox.number import BMWWallboxCurrentLimitNumber
 
+
 async def test_current_limit_number(hass, mock_coordinator, mock_config_entry):
     """Test current limit number entity."""
     number = BMWWallboxCurrentLimitNumber(mock_coordinator, mock_config_entry)
-    
+
     # Test properties
     assert number.name == "Current Limit"
     assert number.native_min_value == 0
     assert number.native_max_value == 32
     assert number.native_step == 1
-    
+
     # Test value
     assert number.native_value == 32.0
 ```
@@ -304,15 +310,17 @@ async def test_current_limit_set_value(hass, mock_coordinator, mock_config_entry
 ### Test Number Availability
 
 ```python
-async def test_current_limit_requires_transaction(hass, mock_coordinator, mock_config_entry):
+async def test_current_limit_requires_transaction(
+    hass, mock_coordinator, mock_config_entry
+):
     """Test current limit is unavailable without transaction."""
     number = BMWWallboxCurrentLimitNumber(mock_coordinator, mock_config_entry)
-    
+
     # With transaction - available
     mock_coordinator.current_transaction_id = "test-123"
     mock_coordinator.data["connected"] = True
     assert number.available is True
-    
+
     # Without transaction - unavailable
     mock_coordinator.current_transaction_id = None
     assert number.available is False
@@ -330,15 +338,16 @@ async def test_current_limit_requires_transaction(hass, mock_coordinator, mock_c
 from homeassistant import config_entries
 from custom_components.bmw_wallbox.const import DOMAIN
 
+
 async def test_config_flow_success(hass):
     """Test successful config flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    
+
     assert result["type"] == "form"
     assert result["step_id"] == "user"
-    
+
     # Mock file existence for SSL validation
     with patch("os.path.isfile", return_value=True):
         result2 = await hass.config_entries.flow.async_configure(
@@ -350,7 +359,7 @@ async def test_config_flow_success(hass):
                 "charge_point_id": "DE*BMW*TEST123",
             },
         )
-    
+
     assert result2["type"] == "create_entry"
     assert result2["title"] == "BMW Wallbox (DE*BMW*TEST123)"
 ```
@@ -389,16 +398,17 @@ async def test_config_flow_invalid_cert(hass):
 ```python
 from unittest.mock import AsyncMock, patch
 
+
 async def test_coordinator_handles_transaction_event(hass, mock_config_entry):
     """Test coordinator processes TransactionEvent."""
     with patch("websockets.serve", new_callable=AsyncMock):
         coordinator = BMWWallboxCoordinator(hass, mock_config_entry.data)
-        
+
         # Simulate TransactionEvent data
         coordinator.data["power"] = 7200.0
         coordinator.data["charging_state"] = "Charging"
         coordinator.data["transaction_id"] = "test-123"
-        
+
         assert coordinator.data["power"] == 7200.0
         assert coordinator.data["charging_state"] == "Charging"
 ```
@@ -426,6 +436,7 @@ async def test_start_charging_no_transaction(mock_coordinator):
 ```python
 # tests/test_new_entity.py
 """Test BMW Wallbox new entity."""
+
 import pytest
 
 from homeassistant.core import HomeAssistant
@@ -436,14 +447,16 @@ from custom_components.bmw_wallbox.new_entity import BMWWallboxNewEntity
 ### Step 2: Write Basic Test
 
 ```python
-async def test_new_entity_value(hass: HomeAssistant, mock_coordinator, mock_config_entry):
+async def test_new_entity_value(
+    hass: HomeAssistant, mock_coordinator, mock_config_entry
+):
     """Test new entity returns correct value."""
     # Add test data to mock
     mock_coordinator.data["new_field"] = "test_value"
-    
+
     # Create entity
     entity = BMWWallboxNewEntity(mock_coordinator, mock_config_entry)
-    
+
     # Assert value
     assert entity.native_value == "test_value"
 ```
@@ -451,13 +464,15 @@ async def test_new_entity_value(hass: HomeAssistant, mock_coordinator, mock_conf
 ### Step 3: Test Properties
 
 ```python
-async def test_new_entity_properties(hass: HomeAssistant, mock_coordinator, mock_config_entry):
+async def test_new_entity_properties(
+    hass: HomeAssistant, mock_coordinator, mock_config_entry
+):
     """Test new entity properties."""
     entity = BMWWallboxNewEntity(mock_coordinator, mock_config_entry)
-    
+
     # Test unique ID
     assert entity.unique_id == f"{mock_config_entry.entry_id}_new_entity"
-    
+
     # Test device info exists
     assert entity.device_info is not None
     assert "identifiers" in entity.device_info
@@ -466,12 +481,14 @@ async def test_new_entity_properties(hass: HomeAssistant, mock_coordinator, mock
 ### Step 4: Test Edge Cases
 
 ```python
-async def test_new_entity_none_value(hass: HomeAssistant, mock_coordinator, mock_config_entry):
+async def test_new_entity_none_value(
+    hass: HomeAssistant, mock_coordinator, mock_config_entry
+):
     """Test new entity handles None value."""
     mock_coordinator.data["new_field"] = None
-    
+
     entity = BMWWallboxNewEntity(mock_coordinator, mock_config_entry)
-    
+
     assert entity.native_value is None
 ```
 
@@ -485,6 +502,7 @@ async def test_new_entity_none_value(hass: HomeAssistant, mock_coordinator, mock
 # Good: Use fixtures
 async def test_something(mock_coordinator, mock_config_entry):
     entity = SomeEntity(mock_coordinator, mock_config_entry)
+
 
 # Avoid: Duplicate setup in every test
 async def test_something():
@@ -502,9 +520,11 @@ async def test_power_value(mock_coordinator, mock_config_entry):
     sensor = PowerSensor(mock_coordinator, mock_config_entry)
     assert sensor.native_value == 7000.0
 
+
 async def test_power_unit(mock_coordinator, mock_config_entry):
     sensor = PowerSensor(mock_coordinator, mock_config_entry)
     assert sensor.native_unit_of_measurement == "W"
+
 
 # Avoid: Multiple unrelated assertions
 async def test_power_sensor(mock_coordinator, mock_config_entry):
@@ -524,6 +544,7 @@ async def test_handles_none(mock_coordinator, mock_config_entry):
     sensor = PowerSensor(mock_coordinator, mock_config_entry)
     assert sensor.native_value is None
 
+
 # Test disconnected state
 async def test_disconnected(mock_coordinator, mock_config_entry):
     mock_coordinator.data["connected"] = False
@@ -536,6 +557,7 @@ async def test_disconnected(mock_coordinator, mock_config_entry):
 # Good: Describes what is being tested
 async def test_current_limit_requires_active_transaction():
     pass
+
 
 # Avoid: Vague names
 async def test_number():

--- a/custom_components/bmw_wallbox/docs/TROUBLESHOOTING.md
+++ b/custom_components/bmw_wallbox/docs/TROUBLESHOOTING.md
@@ -342,7 +342,7 @@ Source: [Teltonika Community Discussion](https://community.teltonika.lt/t/re-sta
    # Default is 15 seconds
    response = await asyncio.wait_for(
        self.charge_point.call(...),
-       timeout=15.0  # Increase if needed
+       timeout=15.0,  # Increase if needed
    )
    ```
 
@@ -394,6 +394,7 @@ Add temporary logging to see all data:
 ```python
 # In any entity or handler
 import json
+
 _LOGGER.debug("Coordinator data: %s", json.dumps(self.coordinator.data, default=str))
 ```
 
@@ -417,12 +418,12 @@ Create a simple script to test:
 import asyncio
 from ocpp.v201 import call
 
+
 async def test_command():
     # ... setup charge_point ...
-    response = await charge_point.call(
-        call.SetChargingProfile(...)
-    )
+    response = await charge_point.call(call.SetChargingProfile(...))
     print(f"Response: {response}")
+
 
 asyncio.run(test_command())
 ```
@@ -433,8 +434,7 @@ Check if entity is in Home Assistant:
 
 ```python
 # In __init__.py after platform setup
-_LOGGER.info("Registered entities: %s", 
-    [e.entity_id for e in hass.states.async_all()])
+_LOGGER.info("Registered entities: %s", [e.entity_id for e in hass.states.async_all()])
 ```
 
 ---


### PR DESCRIPTION
Every action was referenced by floating tag. This pins them all to commit SHAs and adds Dependabot to keep the pins current.

**Why it matters**

- `hacs/action@main` and `hassfest@master` ran whatever was on those branches at the time — including inside `release.yml`, which holds `contents: write`.
- `@v4`/`@v5` only move within their major, so the repo sat on checkout v4 and setup-python v5 indefinitely with nothing reporting it.
- `validate.yml` had drifted further still: checkout **v3**, while the other two workflows in this repo were on v4.

**What changed**

- All actions pinned to SHA, at their current releases: checkout v7.0.1, setup-python v7.0.0, codecov-action v7.0.0, action-gh-release v3.0.2, plus the HACS and hassfest branch heads.
- New `.github/dependabot.yml`, weekly, with updates **grouped** into a single PR — ungrouped, a week with four action releases means four PRs all touching the same files.

Mirrors the setup already in `curgasnatural-ha`.