### PR TITLE
fix: apply current limit to the running session, not just the next one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.6] - 2026-08-15
+
+### Fixed
+
+- **Current-limit changes were reported as applied while the car kept charging at the old limit** - a `TxDefaultProfile` only takes effect from the START of the next transaction, so it cannot limit a session already in progress; only the `TxProfile` can. The success check was `ok_default or ok_tx`, written for the opposite case (Delta Gen 4 rejecting the persistent `TxDefaultProfile` while honouring the per-session `TxProfile`, [#14](https://github.com/JoaoPedroBelo/bmw-wallbox-ha/issues/14)). When the combination reversed, `number.charging_current_limit` reported the new value while the wallbox was still on the old one. Measured live on 2026-08-15: a 6 A limit was "applied" at 13:00:53 and the car drew 21.4 A for 14 minutes, putting the grid at 34.6 A on a 30 A supply. Because Home Assistant trusted the entity, every downstream load-management guard was blinded. With an active transaction the sequence now fails, and logs, when the `TxProfile` is rejected.
+- **The current-limit path did not refresh the transaction id before building the `TxProfile`** - a `TxProfile` is bound to a specific transaction, so a stale id makes the wallbox reject the only profile that can limit the running session. The id goes stale easily: pause/resume keep the transaction alive by design and the wallbox does not always announce a new one with `TransactionEvent(Started)`. The pause and resume paths already refreshed before acting; the limit path was the one that did not, and the one that failed.
+
 ## [1.7.5] - 2026-07-12
 
 ### Fixed

--- a/custom_components/bmw_wallbox/coordinator.py
+++ b/custom_components/bmw_wallbox/coordinator.py
@@ -1653,6 +1653,17 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
 
     async def _run_limit_sequence(self, limit: float) -> bool:
         """Clear existing profiles and install the new limit."""
+        # Re-read the transaction id from the wallbox first. A TxProfile is bound
+        # to a specific transaction, so a stale id makes the box reject the only
+        # profile that can limit the session in progress. The id goes stale
+        # easily: pause/resume keep the transaction alive on purpose, and the box
+        # does not always announce a new one with a TransactionEvent(Started) —
+        # on 2026-08-15 sensor.transaction_id held the same value across a
+        # Paused -> Car Paused -> Charging cycle while a new session ran.
+        # The pause and resume paths already refresh before acting; the limit
+        # path did not, which is why it was the one that failed.
+        await self.async_refresh_transaction_id()
+
         _LOGGER.info(
             "⚡ Setting current limit to %sA (tx=%s)",
             limit,
@@ -1698,6 +1709,33 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
                 profile_id=998,
                 stack_level=0,
             )
+
+            # A TxDefaultProfile applies from the START of the next transaction
+            # (OCPP 2.0.1). It does NOT touch a session that is already running.
+            # So while a transaction is live, ok_tx is the ONLY evidence that the
+            # car is actually limited; ok_default alone means "the next session
+            # will be limited" and nothing more.
+            #
+            # This used to be `if ok_default or ok_tx`, written for the opposite
+            # case (Delta Gen 4 rejecting the persistent TxDefaultProfile while
+            # honouring the per-session TxProfile, issue #14). The reverse
+            # combination silently reported success: on 2026-08-15 13:00:53 a
+            # 6 A limit was "applied" while the car kept drawing 21.4 A for
+            # 14 minutes, putting the grid at 34.6 A on a 30 A contract. Home
+            # Assistant believed the entity, so every load-management guard was
+            # blinded — the emergency branch requires `limit > 6` and the limit
+            # "was" 6. Reporting failure is what lets the caller react.
+            if self.current_transaction_id and not ok_tx:
+                _LOGGER.error(
+                    "❌ Current limit %sA NOT applied to the running session: "
+                    "TxProfile rejected (tx=%s). TxDefaultProfile accepted=%s, "
+                    "which only affects the NEXT session - the car is still on "
+                    "its previous limit",
+                    limit,
+                    self.current_transaction_id,
+                    ok_default,
+                )
+                return False
 
             if ok_default or ok_tx:
                 # Track the new limit for future start/resume/connect operations

--- a/custom_components/bmw_wallbox/manifest.json
+++ b/custom_components/bmw_wallbox/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "ocpp>=0.20.0"
   ],
-  "version": "1.7.5"
+  "version": "1.7.6"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -950,7 +950,11 @@ async def test_set_current_limit_clears_profiles_first_with_transaction(coordina
     assert await coordinator.async_set_current_limit(13.0) is True
 
     sent = [type(c.args[0]).__name__ for c in mock_cp.call.call_args_list]
-    assert sent[0] == "ClearChargingProfile"
+    # The sequence now re-reads the transaction id first: a TxProfile is bound to
+    # a transaction, and a stale id makes the box reject the only profile that
+    # can limit the session in progress.
+    assert sent[0] == "GetTransactionStatus"
+    assert sent[1] == "ClearChargingProfile"
     # TxProfile (immediate) before TxDefaultProfile (next-session persistence)
     purposes = _profile_purposes(mock_cp.call)
     assert purposes == [
@@ -998,7 +1002,8 @@ async def test_set_current_limit_survives_cancellation(coordinator):
             await asyncio.sleep(0)
 
     sent = [type(c.args[0]).__name__ for c in mock_cp.call.call_args_list]
-    assert sent[0] == "ClearChargingProfile"
+    assert sent[0] == "GetTransactionStatus"
+    assert sent[1] == "ClearChargingProfile"
     assert _profile_purposes(mock_cp.call) == [
         ChargingProfilePurposeEnumType.tx_profile,
         ChargingProfilePurposeEnumType.tx_default_profile,
@@ -1043,9 +1048,11 @@ async def test_set_current_limit_sequences_do_not_interleave(coordinator):
     # Old sequence ran to completion first, then the new one - no interleaving.
     sent = [type(c.args[0]).__name__ for c in mock_cp.call.call_args_list]
     assert sent == [
+        "GetTransactionStatus",
         "ClearChargingProfile",
         "SetChargingProfile",
         "SetChargingProfile",
+        "GetTransactionStatus",
         "ClearChargingProfile",
         "SetChargingProfile",
         "SetChargingProfile",
@@ -1381,3 +1388,99 @@ async def test_short_external_timeout_desyncs_queue_regression(coordinator, capl
         pump.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await pump
+
+
+# ---------------------------------------------------------------------------
+# TxProfile rejection must not report success (2026-08-15)
+#
+# A TxDefaultProfile applies from the START of the next transaction; it does not
+# touch a running session. `if ok_default or ok_tx` therefore reported success
+# whenever the default landed, even though the car was still on its previous
+# limit. Live consequence: 13:00:53 a 6 A limit was "applied", the car kept
+# drawing 21.4 A for 14 minutes, and the grid sat at 34.6 A on a 30 A contract.
+# Home Assistant believed the entity, so every load guard was blinded — the
+# emergency branch requires `limit > 6` and the limit "was" 6.
+# ---------------------------------------------------------------------------
+
+
+def _profile_response(accepted_purposes):
+    """Accept SetChargingProfile only for the listed purposes."""
+
+    async def call(payload):
+        response = MagicMock()
+        response.status_info = None
+        if type(payload).__name__ == "SetChargingProfile":
+            purpose = payload.charging_profile.charging_profile_purpose
+            response.status = "Accepted" if purpose in accepted_purposes else "Rejected"
+        else:
+            response.status = "Accepted"
+        return response
+
+    return call
+
+
+async def test_limit_fails_when_tx_profile_rejected_during_session(coordinator):
+    """Session live + TxProfile rejected => failure, even if default accepted."""
+    mock_cp = MagicMock()
+    mock_cp.call = AsyncMock(
+        side_effect=_profile_response(
+            {ChargingProfilePurposeEnumType.tx_default_profile}
+        )
+    )
+    coordinator.charge_point = mock_cp
+    coordinator.current_transaction_id = "tx-123"
+    coordinator.async_refresh_transaction_id = AsyncMock()
+
+    assert await coordinator.async_set_current_limit(6.0) is False
+    # The entity must NOT claim the car is limited when it is not.
+    assert coordinator.data.get("current_limit") != 6.0
+
+
+async def test_limit_succeeds_when_tx_profile_accepted_and_default_rejected(
+    coordinator,
+):
+    """The original issue #14 case still passes: only the TxProfile matters."""
+    mock_cp = MagicMock()
+    mock_cp.call = AsyncMock(
+        side_effect=_profile_response({ChargingProfilePurposeEnumType.tx_profile})
+    )
+    coordinator.charge_point = mock_cp
+    coordinator.current_transaction_id = "tx-123"
+    coordinator.async_refresh_transaction_id = AsyncMock()
+    coordinator.async_set_updated_data = MagicMock()
+
+    assert await coordinator.async_set_current_limit(6.0) is True
+    assert coordinator.data["current_limit"] == 6.0
+
+
+async def test_limit_succeeds_with_default_only_when_no_session(coordinator):
+    """With no transaction there is nothing to limit now; the default is enough."""
+    mock_cp = MagicMock()
+    mock_cp.call = AsyncMock(
+        side_effect=_profile_response(
+            {ChargingProfilePurposeEnumType.tx_default_profile}
+        )
+    )
+    coordinator.charge_point = mock_cp
+    coordinator.current_transaction_id = None
+    coordinator.async_refresh_transaction_id = AsyncMock()
+    coordinator.async_set_updated_data = MagicMock()
+
+    assert await coordinator.async_set_current_limit(16.0) is True
+    assert coordinator.data["current_limit"] == 16.0
+
+
+async def test_limit_sequence_refreshes_transaction_id_first(coordinator):
+    """A stale transaction id is what made the box reject the TxProfile."""
+    mock_cp = MagicMock()
+    mock_response = MagicMock()
+    mock_response.status = "Accepted"
+    mock_response.status_info = None
+    mock_cp.call = AsyncMock(return_value=mock_response)
+    coordinator.charge_point = mock_cp
+    coordinator.current_transaction_id = "stale-tx"
+    coordinator.async_refresh_transaction_id = AsyncMock()
+
+    await coordinator.async_set_current_limit(16.0)
+
+    coordinator.async_refresh_transaction_id.assert_awaited_once()


### PR DESCRIPTION
## The bug

`number.charging_current_limit` reported a limit as applied while the car kept charging at the previous one.

A `TxDefaultProfile` only takes effect from the **start of the next transaction**, so it cannot limit a session already in progress — only a `TxProfile` can. Two defects combined:

1. **`_run_limit_sequence` never refreshed the transaction id.** A `TxProfile` is bound to a specific transaction, so a stale id makes the wallbox reject the only profile that can limit the running session. The id goes stale easily: pause/resume keep the transaction alive by design, and the wallbox does not always announce a new one with `TransactionEvent(Started)`. `async_pause_charging` and `async_resume_charging` already refreshed before acting — the limit path was the one that did not, and the one that failed.

2. **The success check was `ok_default or ok_tx`.** That was written for the opposite combination (Delta Gen 4 rejecting the persistent `TxDefaultProfile` while honouring the per-session `TxProfile`, #14). When it reversed, the sequence reported success on the strength of a profile that does not affect the current session, and wrote the new value into `data["current_limit"]`.

## Measured impact

Live on 2026-08-15, single-phase 6.9 kVA (30 A) supply:

| Time | Event |
|---|---|
| 13:00:53 | limit commanded 24 A → 6 A, entity reports **6 A** |
| 13:00:52 → 13:14:12 | `sensor.power` stays at **~5080 W (21.4 A)**, never responds |
| | grid import reaches **34.6 A on a 30 A contract** |

Because Home Assistant trusted the entity, every downstream load-management guard was blinded: an emergency cut conditioned on `limit > 6` cannot fire when the limit "is" 6.

After the fix, the same 6 A command was obeyed in ~20 s and grid import fell from 7369 W to 3119 W.

## The change

- Refresh the transaction id at the start of `_run_limit_sequence`, matching what the pause and resume paths already did.
- With an active transaction, fail (and log at `error`) when the `TxProfile` is rejected, instead of reporting success because the `TxDefaultProfile` landed. With no transaction, the default alone is still enough.

## Tests

4 new cases in `tests/test_coordinator.py`:

- `test_limit_fails_when_tx_profile_rejected_during_session` — the regression itself; the entity must not claim a limit that was not applied
- `test_limit_succeeds_when_tx_profile_accepted_and_default_rejected` — #14 still passes
- `test_limit_succeeds_with_default_only_when_no_session` — no transaction, default is enough
- `test_limit_sequence_refreshes_transaction_id_first`

Three existing call-sequence assertions updated for the added `GetTransactionStatus`.

`139 passed`, `ruff check` and `ruff format --check` clean.