### PR TITLE
fix: install TxDefaultProfile only to stop mid-session limit orphaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-08-29
+
+### Fixed
+
+- **Current-limit changes stopped applying mid-session until the wallbox was rebooted (the recurring "I raise the limit and the watts don't change" bug).** Root-caused live on the real Delta Gen 4 (firmware `01.20.06.71`) by capturing raw OCPP frames: the integration installed a transaction-bound `TxProfile` (id 999), and after a mid-session `SuspendedEVSE`/connector-`Faulted` event the Delta **refuses to clear or replace it** — `ClearChargingProfile` returns `Unknown` (by id AND by criteria) and a duplicate `SetChargingProfile` returns `Rejected`. The transaction becomes "orphaned" and every later limit change is silently rejected until a reboot forces a new transaction (`GetChargingProfiles` at 53% SoC showed a stuck id 999 27 A `TxProfile` while the car drew 23.8 A and every 8/10/27 A change was `Rejected`). The integration now installs **only a `TxDefaultProfile`** (no `transactionId`) across every path — limit changes, session start, pause (0 A) and resume — so nothing can pin itself to a faulted transaction. A `TxDefaultProfile` is replaced in place by this firmware (measured live 32→10→6 A all `Accepted`) and drives the composite schedule while no `TxProfile` overlays it, so mid-session control works without a reboot. This removes the `TxProfile`/refresh/clear machinery from [#14](https://github.com/JoaoPedroBelo/bmw-wallbox-ha/issues/14)/[#18](https://github.com/JoaoPedroBelo/bmw-wallbox-ha/issues/18)/[#24](https://github.com/JoaoPedroBelo/bmw-wallbox-ha/issues/24) that created the profile that got stuck.
+
+### Added
+
+- **`sensor.enforced_current_limit`** — the current limit the wallbox is *actually* enforcing, read via `GetCompositeSchedule` each poll. Unlike `number.charging_current_limit` (what Home Assistant asked for), this shows the truth, so a rejected/ignored limit is visible instead of silent.
+- **`binary_sensor.fault`** — surfaces a connector `Faulted` (the trigger that orphaned the transaction) and NotifyEvent alerts as a first-class Home Assistant state, with the reason and timestamp as `last_fault`/`last_fault_time` attributes and a `stuck_tx_profile` flag when a leftover transaction-bound profile is detected. Home Assistant history/logbook gives the fault timeline. Entity only — no push notifications.
+- **`ReportChargingProfiles` handler** — previously the reply to `GetChargingProfiles` threw `NotImplementedError`; it is now parsed, storing the installed profiles for diagnostics and warning when a stuck `TxProfile` is present.
+- **`sensor.max_charging_current`** — the hardware max current configured on the wallbox, read via `GetVariables` (the real ceiling for load management).
+- **`number.led_brightness`** — read (`GetVariables`) and write (`SetVariables`) the wallbox LED brightness. Also corrects the LED variable, which used the wrong device-model path (`ChargingStation.StatusLedBrightness` → `UnknownVariable`); it is `StatusLED.brightness`, so LED control now actually takes effect.
+- **The "Maximum Current (A)" option is now bounded by the wallbox** — the config/options field is capped at the value the wallbox reports (`GetVariables` `MaxCurrent`, also `sensor.max_charging_current`) and defaults to it, so you can only pick a limit between the 6 A minimum and the real hardware maximum (a saved value still wins as the default). The `number.charging_current_limit` slider ceiling follows that option.
+
+### Removed
+
+- **Transaction-bound `TxProfile` charging profiles** are no longer sent by any code path — the integration is `TxDefaultProfile`-only. This is the breaking behavioural change that warrants the major version: the whole `TxProfile` + transaction-id-refresh + clear-before-set strategy from #14/#18/#24 is gone.
+- **`coordinator.async_refresh_transaction_id()`** (and its `GetTransactionStatus` call) — it only existed to validate a transaction id before building a `TxProfile`; with no `TxProfile`, nothing needs it. The `transaction_id` is still tracked as an "active session" signal and exposed as `sensor.transaction_id`.
+
 ## [1.7.6] - 2026-08-15
 
 ### Fixed

--- a/custom_components/bmw_wallbox/binary_sensor.py
+++ b/custom_components/bmw_wallbox/binary_sensor.py
@@ -9,11 +9,17 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import BINARY_SENSOR_CHARGING, BINARY_SENSOR_CONNECTED, DOMAIN
+from .const import (
+    BINARY_SENSOR_CHARGING,
+    BINARY_SENSOR_CONNECTED,
+    BINARY_SENSOR_FAULT,
+    DOMAIN,
+)
 from .coordinator import BMWWallboxCoordinator
 
 
@@ -30,6 +36,7 @@ async def async_setup_entry(
             # Connection status should be first (most important!)
             BMWWallboxConnectedBinarySensor(coordinator, entry),
             BMWWallboxChargingBinarySensor(coordinator, entry),
+            BMWWallboxFaultBinarySensor(coordinator, entry),
         ]
     )
 
@@ -98,3 +105,45 @@ class BMWWallboxConnectedBinarySensor(BMWWallboxBinarySensorBase):
         return {
             "last_heartbeat": last_heartbeat.isoformat() if last_heartbeat else None,
         }
+
+
+class BMWWallboxFaultBinarySensor(BMWWallboxBinarySensorBase):
+    """Fault indicator (connector Faulted or a stuck transaction-bound TxProfile).
+
+    A mid-session connector ``Faulted`` is what silently orphaned the
+    transaction on the Delta firmware (issue #25); ``stuck_tx_profile`` flags a
+    leftover TxProfile the box refuses to clear (reboot needed). Entity only -
+    the integration never sends push notifications; the user wires their own.
+    """
+
+    def __init__(
+        self,
+        coordinator: BMWWallboxCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the fault binary sensor."""
+        super().__init__(coordinator, entry, BINARY_SENSOR_FAULT)
+        self._attr_name = "Fault"
+        self._attr_device_class = BinarySensorDeviceClass.PROBLEM
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when the wallbox reports a fault or a stuck profile."""
+        return bool(
+            self.coordinator.data.get("wallbox_fault")
+            or self.coordinator.data.get("stuck_tx_profile")
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Return the last fault reason and whether a profile is stuck."""
+        attrs: dict[str, str] = {}
+        if self.coordinator.data.get("last_fault"):
+            attrs["last_fault"] = self.coordinator.data["last_fault"]
+        if self.coordinator.data.get("last_fault_time"):
+            attrs["last_fault_time"] = self.coordinator.data["last_fault_time"]
+        attrs["stuck_tx_profile"] = str(
+            bool(self.coordinator.data.get("stuck_tx_profile"))
+        )
+        return attrs

--- a/custom_components/bmw_wallbox/config_flow.py
+++ b/custom_components/bmw_wallbox/config_flow.py
@@ -134,10 +134,26 @@ class OptionsFlow(config_entries.OptionsFlow):
             CONF_RFID_TOKEN,
             self.config_entry.data.get(CONF_RFID_TOKEN, ""),
         )
-        current_max = self.config_entry.options.get(
-            CONF_MAX_CURRENT,
-            self.config_entry.data.get(CONF_MAX_CURRENT, DEFAULT_MAX_CURRENT),
+        # The wallbox-reported max (GetVariables MaxCurrent, stored on the
+        # coordinator) is the hard ceiling for "Maximum Current (A)": you can pick
+        # any limit between the 6 A minimum and whatever the box reports. If the
+        # box says 25 A you cannot go above 25; if it reported 300 the slider would
+        # go to 300. Until the box has reported, fall back to a generous 63 A.
+        domain_data = self.hass.data.get(DOMAIN) or {}
+        coordinator = (
+            domain_data.get(self.config_entry.entry_id) if domain_data else None
         )
+        wallbox_max = coordinator.data.get("max_current_a") if coordinator else None
+        max_ceiling = int(wallbox_max) if wallbox_max else 63
+
+        configured_max = self.config_entry.options.get(
+            CONF_MAX_CURRENT,
+            int(wallbox_max)
+            if wallbox_max
+            else self.config_entry.data.get(CONF_MAX_CURRENT, DEFAULT_MAX_CURRENT),
+        )
+        # Never present a default above the ceiling the box allows.
+        current_max = max(6, min(int(configured_max), max_ceiling))
         current_scan = self.config_entry.options.get(
             CONF_SCAN_INTERVAL,
             self.config_entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
@@ -149,7 +165,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                 {
                     vol.Optional(CONF_RFID_TOKEN, default=current_rfid): str,
                     vol.Optional(CONF_MAX_CURRENT, default=current_max): vol.All(
-                        vol.Coerce(int), vol.Range(min=6, max=63)
+                        vol.Coerce(int), vol.Range(min=6, max=max_ceiling)
                     ),
                     vol.Optional(CONF_SCAN_INTERVAL, default=current_scan): vol.All(
                         vol.Coerce(int), vol.Range(min=5, max=60)

--- a/custom_components/bmw_wallbox/const.py
+++ b/custom_components/bmw_wallbox/const.py
@@ -53,6 +53,7 @@ SENSOR_ENERGY_REACTIVE_EXPORT: Final = "energy_reactive_export"
 
 BINARY_SENSOR_CHARGING: Final = "charging"
 BINARY_SENSOR_CONNECTED: Final = "connected"
+BINARY_SENSOR_FAULT: Final = "fault"
 BINARY_SENSOR_CAR_CONNECTED: Final = "car_connected"
 BINARY_SENSOR_AVAILABLE: Final = "available"
 

--- a/custom_components/bmw_wallbox/coordinator.py
+++ b/custom_components/bmw_wallbox/coordinator.py
@@ -8,6 +8,7 @@ Not affiliated with BMW, Delta Electronics, or any other company.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from datetime import UTC, datetime, timedelta
 import logging
 import ssl
@@ -22,6 +23,7 @@ from ocpp.v201.datatypes import (
     ChargingSchedulePeriodType,
     ChargingScheduleType,
     ComponentType,
+    GetVariableDataType,
     IdTokenType,
     SetVariableDataType,
     VariableType,
@@ -169,6 +171,19 @@ class WallboxChargePoint(cp):
         self.coordinator.data["connector_status"] = connector_status
         self.coordinator.data["evse_id"] = evse_id
         self.coordinator.data["connector_id"] = connector_id
+
+        # Surface a connector fault as a first-class state. A mid-session
+        # "Faulted" is exactly what silently orphaned the transaction on the
+        # Delta firmware (issue #25); it must be visible in HA, not buried in a
+        # log line. Entities only - the integration never sends notifications.
+        if connector_status == "Faulted":
+            self.coordinator.data["wallbox_fault"] = True
+            self.coordinator.data["last_fault"] = "Connector Faulted"
+            self.coordinator.data["last_fault_time"] = datetime.utcnow().isoformat()
+            _LOGGER.warning("⚠️ Connector FAULTED (EVSE=%s)", evse_id)
+        elif connector_status in ("Available", "Occupied"):
+            self.coordinator.data["wallbox_fault"] = False
+
         self.coordinator.async_set_updated_data(self.coordinator.data)
 
         return call_result.StatusNotification()
@@ -519,8 +534,24 @@ class WallboxChargePoint(cp):
 
         Some chargers send this frequently. We accept it to avoid repeated
         NotImplementedError / KeyError that can overload HA logs and event loop.
+        We also surface Alert/Fault events as a fault state so they are visible
+        in HA (entities only, no notifications - issue #25).
         """
         _LOGGER.debug("NotifyEvent received: %s", kwargs)
+        for event in kwargs.get("event_data", []) or []:
+            trigger = str(event.get("trigger", ""))
+            if trigger not in ("Alerting", "Delta"):
+                continue
+            comp = (event.get("component") or {}).get("name", "?")
+            var = (event.get("variable") or {}).get("name", "?")
+            reason = f"{comp}.{var}={event.get('actual_value', '')}"
+            tech = event.get("tech_info")
+            if tech:
+                reason += f" ({tech})"
+            self.coordinator.data["last_fault"] = reason
+            self.coordinator.data["last_fault_time"] = datetime.utcnow().isoformat()
+            _LOGGER.warning("⚠️ Wallbox NotifyEvent alert: %s", reason)
+            self.coordinator.async_set_updated_data(self.coordinator.data)
         return call_result.NotifyEvent()
 
     @on("NotifyEVChargingNeeds")
@@ -560,6 +591,46 @@ class WallboxChargePoint(cp):
         """
         _LOGGER.debug("ClearedChargingLimit received: %s", kwargs)
         return call_result.ClearedChargingLimit()
+
+    @on("ReportChargingProfiles")
+    async def on_report_charging_profiles(
+        self, request_id, charging_limit_source, charging_profile, evse_id, **kwargs
+    ):
+        """Handle ReportChargingProfiles - the reply to GetChargingProfiles.
+
+        Without a handler the ocpp library answers with a CallError
+        (NotImplementedError) and the query is lost. We store the reported
+        profiles so a diagnostic can see exactly what the wallbox has installed,
+        and warn if a transaction-bound ``TxProfile`` is present: the integration
+        never installs one anymore (issue #25), so a lingering TxProfile means a
+        profile is stuck to the transaction and mid-session limit changes will be
+        silently rejected until the wallbox is rebooted.
+        """
+        profiles = charging_profile or []
+        # tbc (to-be-continued) => more pages follow; accumulate, else replace.
+        if kwargs.get("tbc"):
+            self.coordinator.data.setdefault("installed_profiles", []).extend(profiles)
+        else:
+            existing = self.coordinator.data.get("installed_profiles", [])
+            self.coordinator.data["installed_profiles"] = existing + profiles
+
+        all_profiles = self.coordinator.data.get("installed_profiles", [])
+        stuck = [
+            p
+            for p in all_profiles
+            if p.get("charging_profile_purpose") == "TxProfile"
+            or p.get("chargingProfilePurpose") == "TxProfile"
+        ]
+        self.coordinator.data["stuck_tx_profile"] = bool(stuck)
+        if stuck:
+            _LOGGER.warning(
+                "⚠️ Wallbox has a stuck transaction-bound TxProfile installed "
+                "(%s); mid-session limit changes may be rejected until reboot: %s",
+                len(stuck),
+                stuck,
+            )
+        self.coordinator.async_set_updated_data(self.coordinator.data)
+        return call_result.ReportChargingProfiles()
 
 
 class BMWWallboxCoordinator(DataUpdateCoordinator):
@@ -669,6 +740,9 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
         # so we can't rely purely on push-based updates.
         if self.charge_point and self.current_transaction_id:
             await self.async_trigger_meter_values()
+            # Read the limit the wallbox is actually enforcing (issue #25) so
+            # sensor.enforced_current_limit reflects the truth, not the request.
+            await self.async_get_composite_schedule()
         return self.data
 
     async def async_configure_wallbox_for_pause_resume(self) -> None:
@@ -759,6 +833,12 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
             # Install TxDefaultProfile so the first session starts at the limit
             asyncio.create_task(self._apply_default_limit_on_connect())
 
+            # Read installed profiles for the stuck-TxProfile diagnostic (issue #25)
+            asyncio.create_task(self._get_profiles_on_connect())
+
+            # Read device-model config (hardware max current, LED brightness)
+            asyncio.create_task(self._read_config_on_connect())
+
             try:
                 await self.charge_point.start()
             except websockets.exceptions.ConnectionClosed:
@@ -784,6 +864,58 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
         if self.charge_point:
             _LOGGER.info("Requesting meter values on connect...")
             await self.async_trigger_meter_values()
+
+    async def _get_profiles_on_connect(self) -> None:
+        """Read installed charging profiles a few seconds after connect."""
+        await asyncio.sleep(5)
+        if self.charge_point:
+            await self.async_get_charging_profiles()
+
+    async def _read_config_on_connect(self) -> None:
+        """Read slow-changing device-model config once after connect.
+
+        The hardware max current (the real ceiling for load management) and the
+        LED brightness (issue #25 / feature #5). GetVariables is a plain read.
+        """
+        await asyncio.sleep(6)
+        if not self.charge_point:
+            return
+        max_a = await self.async_get_variable("ChargingStation", "MaxCurrent")
+        if max_a is not None:
+            with contextlib.suppress(ValueError, TypeError):
+                self.data["max_current_a"] = float(max_a)
+        led = await self.async_get_variable("StatusLED", "brightness")
+        if led is not None:
+            with contextlib.suppress(ValueError, TypeError):
+                self.data["led_brightness"] = int(float(led))
+        self.async_set_updated_data(self.data)
+
+    async def async_get_variable(self, component: str, variable: str) -> str | None:
+        """Read a single device-model variable via GetVariables (OCPP 2.0.1)."""
+        if not self.charge_point:
+            return None
+        try:
+            response = await self._ocpp_call(
+                call.GetVariables(
+                    get_variable_data=[
+                        GetVariableDataType(
+                            component=ComponentType(name=component),
+                            variable=VariableType(name=variable),
+                        )
+                    ]
+                )
+            )
+            results = getattr(response, "get_variable_result", None) or []
+            if not results:
+                return None
+            res = results[0]
+            status = res.get("attribute_status") or res.get("attributeStatus")
+            if status != "Accepted":
+                return None
+            return res.get("attribute_value") or res.get("attributeValue")
+        except Exception as err:  # best-effort read
+            _LOGGER.debug("GetVariables(%s.%s) failed: %s", component, variable, err)
+            return None
 
     async def _recover_transaction_on_connect(self) -> None:
         """Recover active transaction state after wallbox connects.
@@ -950,33 +1082,19 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
                         "transaction_id"
                     )
                     if tx_id:
-                        start_time = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-                        schedule = ChargingScheduleType(
-                            id=1,
-                            start_schedule=start_time,
-                            charging_rate_unit=ChargingRateUnitEnumType.amps,
-                            charging_schedule_period=[
-                                ChargingSchedulePeriodType(
-                                    start_period=0, limit=float(max_current)
-                                )
-                            ],
-                        )
-
-                        profile = ChargingProfileType(
-                            id=999,
+                        # TxDefaultProfile only (never a transaction-bound TxProfile).
+                        # See _run_limit_sequence for why: a TxProfile gets stuck to
+                        # a faulted transaction and orphans mid-session control.
+                        ok = await self._send_charging_profile(
+                            float(max_current),
+                            purpose=ChargingProfilePurposeEnumType.tx_default_profile,
+                            profile_id=998,
                             stack_level=0,
-                            charging_profile_purpose=ChargingProfilePurposeEnumType.tx_profile,
-                            charging_profile_kind=ChargingProfileKindEnumType.absolute,
-                            transaction_id=tx_id,
-                            charging_schedule=[schedule],
-                        )
-
-                        profile_response = await self._ocpp_call(
-                            call.SetChargingProfile(evse_id=1, charging_profile=profile)
                         )
                         _LOGGER.info(
-                            "SetChargingProfile response: %s", profile_response.status
+                            "SetChargingProfile(TxDefault %dA) accepted=%s",
+                            max_current,
+                            ok,
                         )
 
                         # Wait for charging to ramp up and request meter values
@@ -1164,61 +1282,6 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
 
         return await self.async_start_charging(status_callback)
 
-    async def async_refresh_transaction_id(self) -> str | None:
-        """Query the wallbox to get/verify the current transaction ID.
-
-        Uses GetTransactionStatus to verify the transaction is still active.
-        Returns the transaction_id if valid, None otherwise.
-        """
-        if not self.charge_point:
-            _LOGGER.warning("Cannot refresh transaction ID - no wallbox connected")
-            return None
-
-        if not self.current_transaction_id:
-            _LOGGER.debug("No transaction ID to refresh")
-            return None
-
-        _LOGGER.info(
-            "🔄 Refreshing transaction status for: %s", self.current_transaction_id
-        )
-
-        try:
-            response = await self._ocpp_call(
-                call.GetTransactionStatus(transaction_id=self.current_transaction_id)
-            )
-
-            _LOGGER.info(
-                "GetTransactionStatus response: ongoing=%s, messages_in_queue=%s",
-                response.ongoing_indicator
-                if hasattr(response, "ongoing_indicator")
-                else "N/A",
-                response.messages_in_queue
-                if hasattr(response, "messages_in_queue")
-                else "N/A",
-            )
-
-            # If transaction is ongoing, the ID is valid
-            if hasattr(response, "ongoing_indicator") and response.ongoing_indicator:
-                _LOGGER.info(
-                    "✅ Transaction %s is still active", self.current_transaction_id
-                )
-                return self.current_transaction_id
-            _LOGGER.warning(
-                "⚠️ Transaction %s may have ended (ongoing=%s)",
-                self.current_transaction_id,
-                getattr(response, "ongoing_indicator", None),
-            )
-            # Transaction might have ended - clear it
-            # But don't clear yet, let the caller decide
-            return self.current_transaction_id
-
-        except TimeoutError:
-            _LOGGER.warning("GetTransactionStatus timed out")
-            return self.current_transaction_id  # Return existing ID, let command try
-        except Exception as err:
-            _LOGGER.warning("GetTransactionStatus failed: %s", err)
-            return self.current_transaction_id  # Return existing ID, let command try
-
     async def async_pause_charging(self, allow_nuke: bool = True) -> dict:
         """Pause charging via SetChargingProfile(0A) - EVCC-style.
 
@@ -1236,9 +1299,6 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
             result["message"] = "Wallbox not connected"
             # Can't nuke if not connected
             return result
-
-        # Refresh transaction ID from wallbox before attempting pause
-        await self.async_refresh_transaction_id()
 
         if not self.current_transaction_id:
             result["message"] = "No active charging session"
@@ -1284,13 +1344,14 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
                 ],
             )
 
-            # Use stackLevel=0 for highest priority (same as resume)
+            # TxDefaultProfile only (never a transaction-bound TxProfile): a
+            # TxProfile gets stuck to a faulted transaction and orphans control.
+            # See _run_limit_sequence.
             profile = ChargingProfileType(
-                id=999,
+                id=998,
                 stack_level=0,
-                charging_profile_purpose=ChargingProfilePurposeEnumType.tx_profile,
+                charging_profile_purpose=ChargingProfilePurposeEnumType.tx_default_profile,
                 charging_profile_kind=ChargingProfileKindEnumType.absolute,
-                transaction_id=self.current_transaction_id,
                 charging_schedule=[schedule],
             )
 
@@ -1406,9 +1467,6 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
             result["message"] = "Wallbox not connected"
             return result
 
-        # Refresh transaction ID from wallbox before attempting resume
-        await self.async_refresh_transaction_id()
-
         if not self.current_transaction_id:
             result["message"] = "No active session - try starting first"
             return result
@@ -1427,61 +1485,18 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
             except Exception as e:
                 _LOGGER.debug("ClearChargingProfile failed (OK to ignore): %s", e)
 
-            start_time = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-            schedule = ChargingScheduleType(
-                id=1,
-                start_schedule=start_time,
-                charging_rate_unit=ChargingRateUnitEnumType.amps,
-                charging_schedule_period=[
-                    ChargingSchedulePeriodType(
-                        start_period=0, limit=float(current_limit)
-                    )
-                ],
-            )
-
-            # Use stackLevel=0 for highest priority
-            profile = ChargingProfileType(
-                id=999,
+            # TxDefaultProfile only (never a transaction-bound TxProfile): a
+            # TxProfile gets stuck to a faulted transaction and orphans control.
+            # See _run_limit_sequence.
+            ok = await self._send_charging_profile(
+                float(current_limit),
+                purpose=ChargingProfilePurposeEnumType.tx_default_profile,
+                profile_id=998,
                 stack_level=0,
-                charging_profile_purpose=ChargingProfilePurposeEnumType.tx_profile,
-                charging_profile_kind=ChargingProfileKindEnumType.absolute,
-                transaction_id=self.current_transaction_id,
-                charging_schedule=[schedule],
             )
+            _LOGGER.info("Resume (TxDefault %sA) accepted=%s", current_limit, ok)
 
-            response = await self._ocpp_call(
-                call.SetChargingProfile(evse_id=1, charging_profile=profile)
-            )
-
-            _LOGGER.info("Resume response: %s", response.status)
-
-            # Log additional status info if available
-            if hasattr(response, "status_info") and response.status_info:
-                _LOGGER.info(
-                    "Resume status_info: reason=%s, additional=%s",
-                    response.status_info.get("reason_code", "N/A"),
-                    response.status_info.get("additional_info", "N/A"),
-                )
-
-            # The clear-all above also wiped the persistent TxDefaultProfile.
-            # Reinstall it: the Delta firmware accepts a TxProfile sent while
-            # the transaction is suspended but silently discards it, so without
-            # this safety net the session resumes at the hardware maximum until
-            # the next limit change (issue #19).
-            try:
-                await self._send_charging_profile(
-                    float(current_limit),
-                    purpose=ChargingProfilePurposeEnumType.tx_default_profile,
-                    profile_id=998,
-                    stack_level=0,
-                )
-            except Exception as err:
-                _LOGGER.warning(
-                    "Could not reinstall TxDefaultProfile after resume: %s", err
-                )
-
-            if response.status == "Accepted":
+            if ok:
                 result["success"] = True
                 result["message"] = f"Charging resumed at {current_limit}A"
 
@@ -1492,10 +1507,7 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
 
                 asyncio.create_task(delayed_refresh())
             else:
-                reason = ""
-                if hasattr(response, "status_info") and response.status_info:
-                    reason = f" ({response.status_info.get('reason_code', '')})"
-                result["message"] = f"Resume rejected: {response.status}{reason}"
+                result["message"] = "Resume rejected: TxDefaultProfile not accepted"
 
             return result
 
@@ -1652,99 +1664,44 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
             return await self._run_limit_sequence(limit)
 
     async def _run_limit_sequence(self, limit: float) -> bool:
-        """Clear existing profiles and install the new limit."""
-        # Re-read the transaction id from the wallbox first. A TxProfile is bound
-        # to a specific transaction, so a stale id makes the box reject the only
-        # profile that can limit the session in progress. The id goes stale
-        # easily: pause/resume keep the transaction alive on purpose, and the box
-        # does not always announce a new one with a TransactionEvent(Started) —
-        # on 2026-08-15 sensor.transaction_id held the same value across a
-        # Paused -> Car Paused -> Charging cycle while a new session ran.
-        # The pause and resume paths already refresh before acting; the limit
-        # path did not, which is why it was the one that failed.
-        await self.async_refresh_transaction_id()
+        """Install the current limit as a TxDefaultProfile only (no TxProfile).
 
-        _LOGGER.info(
-            "⚡ Setting current limit to %sA (tx=%s)",
-            limit,
-            self.current_transaction_id,
-        )
+        Why not a transaction-bound TxProfile: the Delta Gen 4 firmware leaves an
+        installed TxProfile in place after a SuspendedEVSE/fault event and then
+        refuses to clear or replace it — ClearChargingProfile returns "Unknown"
+        (by id AND by criteria) and a duplicate SetChargingProfile is "Rejected".
+        The transaction becomes "orphaned": every subsequent mid-session limit
+        change is silently rejected until the wallbox is rebooted. Measured live
+        2026-08-29 at 53% SoC: GetChargingProfiles showed a stuck id=999 27 A
+        TxProfile bound to the running transaction; the car drew 23.8 A while
+        every 8/10/27 A change was Rejected. The whole #14/#18/#24 TxProfile
+        machinery is what created the profile that gets stuck.
+
+        A TxDefaultProfile is not bound to a transaction, so nothing can pin
+        itself to a dead/faulted transaction. This Delta accepts and (per the
+        composite schedule) applies it, and it is the approach EVCC uses across
+        many wallboxes. We therefore install ONLY a TxDefaultProfile and never a
+        TxProfile — no transaction id is needed or sent.
+        """
+        _LOGGER.info("⚡ Setting current limit to %sA (TxDefaultProfile)", limit)
 
         try:
-            # The Delta firmware does NOT replace an existing profile with the
-            # same id/stack - it rejects the duplicate. After any start/resume
-            # (which installs TxProfile id=999) every mid-session limit change
-            # was therefore Rejected (issue #14 retest, seen live). Clear first,
-            # exactly like the proven pause/resume paths do, then reinstall.
-            if self.current_transaction_id:
-                try:
-                    clear_response = await self._ocpp_call(call.ClearChargingProfile())
-                    _LOGGER.debug(
-                        "ClearChargingProfile before limit change: %s",
-                        clear_response.status,
-                    )
-                except Exception as e:
-                    _LOGGER.debug("ClearChargingProfile failed (OK to ignore): %s", e)
-
-            # TxProfile takes effect immediately on the running session.
-            # stack_level 0 matches the pause/resume paths; some Delta firmware
-            # rejects any higher level (ChargingProfileMaxStackLevel=0), and
-            # TxProfile already outranks TxDefaultProfile by purpose alone.
-            ok_tx = False
-            if self.current_transaction_id:
-                ok_tx = await self._send_charging_profile(
-                    limit,
-                    purpose=ChargingProfilePurposeEnumType.tx_profile,
-                    profile_id=999,
-                    stack_level=0,
-                    transaction_id=self.current_transaction_id,
-                )
-
-            # TxDefaultProfile persists across sessions and applies from the
-            # start of the next transaction - prevents the startup overshoot.
-            # Sent after the TxProfile so the running session is limited first.
-            ok_default = await self._send_charging_profile(
+            ok = await self._send_charging_profile(
                 limit,
                 purpose=ChargingProfilePurposeEnumType.tx_default_profile,
                 profile_id=998,
                 stack_level=0,
             )
-
-            # A TxDefaultProfile applies from the START of the next transaction
-            # (OCPP 2.0.1). It does NOT touch a session that is already running.
-            # So while a transaction is live, ok_tx is the ONLY evidence that the
-            # car is actually limited; ok_default alone means "the next session
-            # will be limited" and nothing more.
-            #
-            # This used to be `if ok_default or ok_tx`, written for the opposite
-            # case (Delta Gen 4 rejecting the persistent TxDefaultProfile while
-            # honouring the per-session TxProfile, issue #14). The reverse
-            # combination silently reported success: on 2026-08-15 13:00:53 a
-            # 6 A limit was "applied" while the car kept drawing 21.4 A for
-            # 14 minutes, putting the grid at 34.6 A on a 30 A contract. Home
-            # Assistant believed the entity, so every load-management guard was
-            # blinded — the emergency branch requires `limit > 6` and the limit
-            # "was" 6. Reporting failure is what lets the caller react.
-            if self.current_transaction_id and not ok_tx:
-                _LOGGER.error(
-                    "❌ Current limit %sA NOT applied to the running session: "
-                    "TxProfile rejected (tx=%s). TxDefaultProfile accepted=%s, "
-                    "which only affects the NEXT session - the car is still on "
-                    "its previous limit",
-                    limit,
-                    self.current_transaction_id,
-                    ok_default,
-                )
-                return False
-
-            if ok_default or ok_tx:
+            if ok:
                 # Track the new limit for future start/resume/connect operations
                 self.data["current_limit"] = limit
                 self.async_set_updated_data(self.data)
                 return True
 
-            _LOGGER.warning(
-                "⚠️ Current limit %sA not applied (no profile accepted)", limit
+            # Report failure loudly: the caller (load management) must know the
+            # limit did not take, or it will trust a limit the car is not on.
+            _LOGGER.error(
+                "❌ Current limit %sA not applied: TxDefaultProfile rejected", limit
             )
             return False
 
@@ -1839,6 +1796,68 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
             _LOGGER.error("Failed to trigger meter values: %s", err, exc_info=True)
             return False
 
+    async def async_get_composite_schedule(self) -> float | None:
+        """Ask the wallbox what current limit it is ACTUALLY enforcing.
+
+        The ``number`` entity shows what HA *asked* for; it lies when the wallbox
+        did not apply it. GetCompositeSchedule returns the box's own computed
+        schedule, so we expose the truth (issue #25). Stores the first-period
+        limit in ``data['enforced_limit_a']`` and returns it.
+        """
+        if not self.charge_point:
+            return None
+        try:
+            from ocpp.v201 import call as ocpp_call
+            from ocpp.v201.enums import ChargingRateUnitEnumType
+
+            response = await self._ocpp_call(
+                ocpp_call.GetCompositeSchedule(
+                    duration=300,
+                    evse_id=1,
+                    charging_rate_unit=ChargingRateUnitEnumType.amps,
+                )
+            )
+            schedule = getattr(response, "schedule", None)
+            if not schedule:
+                return None
+            periods = schedule.get("charging_schedule_period") or []
+            if not periods:
+                return None
+            limit = periods[0].get("limit")
+            self.data["enforced_limit_a"] = limit
+            self.async_set_updated_data(self.data)
+            return limit
+        except Exception as err:  # best-effort diagnostic poll
+            _LOGGER.debug("GetCompositeSchedule failed (OK to ignore): %s", err)
+            return None
+
+    async def async_get_charging_profiles(self) -> bool:
+        """Ask the wallbox which charging profiles it has installed.
+
+        The reply arrives asynchronously as ReportChargingProfiles (see
+        ``on_report_charging_profiles``), which stores them and flags a stuck
+        transaction-bound TxProfile. Used on connect for diagnostics (issue #25).
+        """
+        if not self.charge_point:
+            return False
+        try:
+            from ocpp.v201 import call as ocpp_call
+            from ocpp.v201.datatypes import ChargingProfileCriterionType
+
+            # Reset the accumulator so a fresh report is not merged with a stale one.
+            self.data["installed_profiles"] = []
+            response = await self._ocpp_call(
+                ocpp_call.GetChargingProfiles(
+                    request_id=1,
+                    charging_profile=ChargingProfileCriterionType(),
+                    evse_id=1,
+                )
+            )
+            return getattr(response, "status", None) == "Accepted"
+        except Exception as err:  # best-effort diagnostic
+            _LOGGER.debug("GetChargingProfiles failed (OK to ignore): %s", err)
+            return False
+
     async def async_set_led_brightness(self, brightness: int) -> bool:
         """Set LED brightness via SetVariables (0-100%).
 
@@ -1857,8 +1876,8 @@ class BMWWallboxCoordinator(DataUpdateCoordinator):
             set_var = SetVariableDataType(
                 attribute_type=AttributeEnumType.actual,
                 attribute_value=str(brightness),
-                component=ComponentType(name="ChargingStation"),
-                variable=VariableType(name="StatusLedBrightness"),
+                component=ComponentType(name="StatusLED"),
+                variable=VariableType(name="brightness"),
             )
 
             response = await self._ocpp_call(

--- a/custom_components/bmw_wallbox/docs/ENTITIES.md
+++ b/custom_components/bmw_wallbox/docs/ENTITIES.md
@@ -4,11 +4,20 @@
 
 | Platform | File | Count | Base Class |
 |----------|------|-------|------------|
-| Sensor | `sensor.py` | 19 | `BMWWallboxSensorBase` |
-| Binary Sensor | `binary_sensor.py` | 2 | `BMWWallboxBinarySensorBase` |
+| Sensor | `sensor.py` | 21 | `BMWWallboxSensorBase` |
+| Binary Sensor | `binary_sensor.py` | 3 | `BMWWallboxBinarySensorBase` |
 | Button | `button.py` | 4 | `BMWWallboxButtonBase` |
-| Number | `number.py` | 1 | Direct `CoordinatorEntity` |
+| Number | `number.py` | 2 | Direct `CoordinatorEntity` |
 | Switch | `switch.py` | - | Not yet implemented |
+
+### Diagnostic / config entities added in 1.8.0 (issue #25 + feature #5)
+
+| Entity | Source | Purpose |
+|--------|--------|---------|
+| `sensor.enforced_current_limit` | `GetCompositeSchedule` (`data["enforced_limit_a"]`) | The limit the wallbox is *actually* enforcing, vs the requested `number` |
+| `binary_sensor.fault` | `data["wallbox_fault"]` / `data["stuck_tx_profile"]` | Connector `Faulted` or a stuck transaction-bound profile; reason + timestamp as `last_fault`/`last_fault_time` attributes (HA history gives the timeline). Entity only, no push |
+| `sensor.max_charging_current` | `GetVariables` `ChargingStation.MaxCurrent` (`data["max_current_a"]`) | Hardware max current ceiling |
+| `number.led_brightness` | `GetVariables`/`SetVariables` `StatusLedBrightness` (`data["led_brightness"]`) | LED brightness read + write |
 
 ---
 

--- a/custom_components/bmw_wallbox/docs/OCPP_HANDLERS.md
+++ b/custom_components/bmw_wallbox/docs/OCPP_HANDLERS.md
@@ -548,29 +548,41 @@ if response.status == RequestStartStopStatusEnumType.accepted:
 
 ### SetChargingProfile
 
-**Purpose:** Control charging current. **REQUIRES active transaction.**
+**Purpose:** Control charging current. Install **only a `TxDefaultProfile`** —
+never a transaction-bound `TxProfile` (issue #25).
+
+**Why not `TxProfile`:** on the Delta Gen 4 firmware a `TxProfile` gets stuck to
+a transaction after a mid-session `SuspendedEVSE`/connector-`Faulted` event — the
+box then refuses to clear it (`ClearChargingProfile` returns `Unknown` by id and
+by criteria) or replace it (duplicate `SetChargingProfile` returns `Rejected`),
+so every later limit change is silently rejected until a reboot (measured live
+2026-08-29). A `TxDefaultProfile` is not bound to a transaction, is replaced in
+place by this firmware, and drives the composite schedule while no `TxProfile`
+overlays it — so it is the only profile the integration installs, everywhere
+(limit changes, session start, pause 0 A, resume). **No `transaction_id` is
+sent.** Fixed id `998`, `stack_level=0`.
 
 ```mermaid
 flowchart LR
     subgraph Profile["ChargingProfile"]
-        ID["id: 999"]
-        Stack["stack_level: 1"]
-        Purpose["purpose: TxProfile"]
+        ID["id: 998"]
+        Stack["stack_level: 0"]
+        Purpose["purpose: TxDefaultProfile"]
         Kind["kind: Absolute"]
-        TxId["transaction_id: REQUIRED!"]
-        
+
         subgraph Schedule["ChargingSchedule"]
             Start["start_schedule: now"]
             Unit["rate_unit: Amps"]
             Period["period: [{start: 0, limit: 32A}]"]
         end
     end
-    
+
     Profile --> WB[Wallbox]
     WB --> Resp["Response: Accepted/Rejected"]
 ```
 
-**Location:** `coordinator.py:624-648` (pause), `coordinator.py:698-722` (resume)
+**Location:** `coordinator.py` `_run_limit_sequence` (limit changes),
+`async_start_charging` / `async_pause_charging` / `async_resume_charging`.
 
 ```python
 from ocpp.v201.datatypes import (
@@ -584,42 +596,48 @@ from ocpp.v201.enums import (
     ChargingRateUnitEnumType,
 )
 
-# Create schedule
 schedule = ChargingScheduleType(
     id=1,
     start_schedule=datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
     charging_rate_unit=ChargingRateUnitEnumType.amps,
     charging_schedule_period=[
-        ChargingSchedulePeriodType(
-            start_period=0,
-            limit=32.0,  # Amps (0 = pause, 32 = full)
-        )
+        ChargingSchedulePeriodType(start_period=0, limit=32.0),  # 0 = pause
     ],
 )
 
-# Create profile
 profile = ChargingProfileType(
-    id=999,
-    stack_level=1,
-    charging_profile_purpose=ChargingProfilePurposeEnumType.tx_profile,
+    id=998,
+    stack_level=0,
+    charging_profile_purpose=ChargingProfilePurposeEnumType.tx_default_profile,
     charging_profile_kind=ChargingProfileKindEnumType.absolute,
     charging_schedule=[schedule],
-    transaction_id=self.current_transaction_id,  # REQUIRED!
+    # No transaction_id: a TxDefaultProfile is never transaction-bound.
 )
 
-response = await asyncio.wait_for(
-    self.charge_point.call(
-        call.SetChargingProfile(evse_id=1, charging_profile=profile)
-    ),
-    timeout=15.0,
+response = await self._ocpp_call(
+    call.SetChargingProfile(evse_id=1, charging_profile=profile)
 )
-
-if response.status == "Accepted":
-    # Profile applied
-    pass
 ```
 
-**Critical:** `transaction_id` is REQUIRED for `tx_profile` purpose.
+**Critical:** never regress to a `tx_profile`. `tests/test_coordinator.py`
+`test_limit_never_sends_tx_profile_during_session` guards this.
+
+### GetCompositeSchedule / GetChargingProfiles / ReportChargingProfiles
+
+- **`GetCompositeSchedule`** (`async_get_composite_schedule`) — reads the limit
+  the wallbox is *actually* enforcing into `data["enforced_limit_a"]`
+  (`sensor.enforced_current_limit`). The truth, vs the requested `number`.
+- **`GetChargingProfiles`** (`async_get_charging_profiles`, sent on connect) —
+  the reply arrives as **`ReportChargingProfiles`**, handled by
+  `on_report_charging_profiles`: it stores the installed profiles and sets
+  `data["stuck_tx_profile"]` when a lingering transaction-bound `TxProfile` is
+  found. Without this handler the ocpp library answered with a `CallError`.
+
+### GetVariables
+
+`async_get_variable(component, variable)` reads a device-model value (used on
+connect for the hardware `MaxCurrent` → `sensor.max_charging_current` and
+`StatusLedBrightness` → `number.led_brightness`).
 
 ---
 

--- a/custom_components/bmw_wallbox/docs/TROUBLESHOOTING.md
+++ b/custom_components/bmw_wallbox/docs/TROUBLESHOOTING.md
@@ -255,6 +255,28 @@ flowchart TD
 
 ---
 
+### Issue: Limit changes don't apply mid-session (orphaned profile) — fixed in 1.8.0
+
+**Symptoms:**
+- You raise/lower `number.charging_current_limit` and the car keeps drawing the old current.
+- Only a wallbox reboot restores control.
+
+**Cause:** older versions installed a transaction-bound `TxProfile` (id 999). After
+a mid-session `SuspendedEVSE`/connector-`Faulted` event the Delta firmware refuses
+to clear or replace it, so the transaction is "orphaned" and every limit change is
+silently rejected until reboot.
+
+**Fix (1.8.0):** the integration now installs **only a `TxDefaultProfile`** (issue
+#25) — nothing can get stuck to a transaction. If you are on an older version and
+currently orphaned, reboot the wallbox once; from then on it will not recur.
+
+**Diagnose:** `sensor.enforced_current_limit` shows what the box is really
+enforcing (vs the requested `number`), and `binary_sensor.fault` surfaces a
+connector fault and a `stuck_tx_profile` flag (with the reason as an attribute;
+Home Assistant history gives the timeline).
+
+---
+
 ### Issue: Stuck Transaction / Cannot Start Charging
 
 **Symptoms:**

--- a/custom_components/bmw_wallbox/manifest.json
+++ b/custom_components/bmw_wallbox/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "ocpp>=0.20.0"
   ],
-  "version": "1.7.6"
+  "version": "2.0.0"
 }

--- a/custom_components/bmw_wallbox/number.py
+++ b/custom_components/bmw_wallbox/number.py
@@ -11,7 +11,7 @@ import logging
 
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfElectricCurrent
+from homeassistant.const import EntityCategory, UnitOfElectricCurrent
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -33,6 +33,7 @@ async def async_setup_entry(
     async_add_entities(
         [
             BMWWallboxCurrentLimitNumber(coordinator, entry),
+            BMWWallboxLedBrightnessNumber(coordinator, entry),
         ]
     )
 
@@ -62,10 +63,6 @@ class BMWWallboxCurrentLimitNumber(CoordinatorEntity, NumberEntity):
         self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_{NUMBER_CURRENT_LIMIT}"
         self._attr_name = "Charging Current Limit"
-        self._attr_native_max_value = entry.options.get(
-            CONF_MAX_CURRENT,
-            entry.data.get(CONF_MAX_CURRENT, DEFAULT_MAX_CURRENT),
-        )
         # Device info for grouping
         self._attr_device_info = {
             "identifiers": {(DOMAIN, entry.data["charge_point_id"])},
@@ -76,16 +73,26 @@ class BMWWallboxCurrentLimitNumber(CoordinatorEntity, NumberEntity):
             "serial_number": coordinator.device_info.get("serial_number"),
         }
 
+    def _configured_max(self) -> float:
+        """The 'Maximum Current (A)' from the config entry."""
+        return self._entry.options.get(
+            CONF_MAX_CURRENT,
+            self._entry.data.get(CONF_MAX_CURRENT, DEFAULT_MAX_CURRENT),
+        )
+
+    @property
+    def native_max_value(self) -> float:
+        """Slider ceiling - the configured 'Maximum Current (A)'.
+
+        That option defaults from the wallbox-reported max in the options flow,
+        so the ceiling tracks the hardware limit while staying user-overridable.
+        """
+        return self._configured_max()
+
     @property
     def native_value(self) -> float:
         """Return current limit value."""
-        return self.coordinator.data.get(
-            "current_limit",
-            self._entry.options.get(
-                CONF_MAX_CURRENT,
-                self._entry.data.get(CONF_MAX_CURRENT, DEFAULT_MAX_CURRENT),
-            ),
-        )
+        return self.coordinator.data.get("current_limit", self._configured_max())
 
     async def async_set_native_value(self, value: float) -> None:
         """Set new current limit.
@@ -106,3 +113,50 @@ class BMWWallboxCurrentLimitNumber(CoordinatorEntity, NumberEntity):
                 _LOGGER.warning(
                     "Failed to send current limit to wallbox (will apply on next start)"
                 )
+
+
+class BMWWallboxLedBrightnessNumber(CoordinatorEntity, NumberEntity):
+    """LED brightness control (0-100%) via the OCPP device model (feature #5).
+
+    Reads StatusLedBrightness with GetVariables on connect and writes it with
+    the existing SetVariables path.
+    """
+
+    _attr_native_min_value = 0
+    _attr_native_max_value = 100
+    _attr_native_step = 5
+    _attr_mode = NumberMode.SLIDER
+    _attr_icon = "mdi:led-on"
+    _attr_native_unit_of_measurement = "%"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: BMWWallboxCoordinator,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the LED brightness number."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_led_brightness"
+        self._attr_name = "LED Brightness"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry.data["charge_point_id"])},
+            "name": "BMW Wallbox",
+            "manufacturer": coordinator.device_info.get("vendor", "BMW"),
+            "model": coordinator.device_info.get("model", "EIAW-E22KTSE6B04"),
+            "sw_version": coordinator.device_info.get("firmware_version"),
+            "serial_number": coordinator.device_info.get("serial_number"),
+        }
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the last known LED brightness (%)."""
+        return self.coordinator.data.get("led_brightness")
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the LED brightness on the wallbox."""
+        if await self.coordinator.async_set_led_brightness(int(value)):
+            self.coordinator.data["led_brightness"] = int(value)
+            self.coordinator.async_set_updated_data(self.coordinator.data)
+        else:
+            _LOGGER.warning("Failed to set LED brightness to %s%%", int(value))

--- a/custom_components/bmw_wallbox/sensor.py
+++ b/custom_components/bmw_wallbox/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    EntityCategory,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -43,6 +44,8 @@ async def async_setup_entry(
             # === ELECTRICAL MEASUREMENTS ===
             BMWWallboxCurrentSensor(coordinator, entry),
             BMWWallboxVoltageSensor(coordinator, entry),
+            BMWWallboxEnforcedLimitSensor(coordinator, entry),
+            BMWWallboxMaxCurrentSensor(coordinator, entry),
             # === CONNECTION & TRANSACTION INFO ===
             BMWWallboxConnectorStatusSensor(coordinator, entry),
             BMWWallboxTransactionIDSensor(coordinator, entry),
@@ -478,3 +481,51 @@ class BMWWallboxSequenceNumberSensor(BMWWallboxSensorBase):
     def native_value(self) -> int | None:
         """Return sequence number."""
         return self.coordinator.data.get("sequence_number")
+
+
+class BMWWallboxEnforcedLimitSensor(BMWWallboxSensorBase):
+    """The current limit the wallbox is ACTUALLY enforcing (GetCompositeSchedule).
+
+    The ``number.charging_current_limit`` entity shows what HA asked for; this
+    shows what the box computed and is really applying, so a rejected/ignored
+    limit is visible instead of silent (issue #25).
+    """
+
+    def __init__(self, coordinator: BMWWallboxCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(
+            coordinator, entry, "enforced_current_limit", "Enforced Current Limit"
+        )
+        self._attr_device_class = SensorDeviceClass.CURRENT
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_icon = "mdi:speedometer"
+        self._attr_suggested_display_precision = 1
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the enforced limit in amperes."""
+        return self.coordinator.data.get("enforced_limit_a")
+
+
+class BMWWallboxMaxCurrentSensor(BMWWallboxSensorBase):
+    """Hardware max charging current configured on the wallbox (GetVariables).
+
+    The real ceiling (e.g. 32 A) read from the device model, useful as the upper
+    bound for load management instead of a hard-coded value (feature #5).
+    """
+
+    def __init__(self, coordinator: BMWWallboxCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(
+            coordinator, entry, "max_charging_current", "Max Charging Current"
+        )
+        self._attr_device_class = SensorDeviceClass.CURRENT
+        self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+        self._attr_icon = "mdi:car-speed-limiter"
+        self._attr_suggested_display_precision = 0
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the configured hardware max current in amperes."""
+        return self.coordinator.data.get("max_current_a")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,8 +6,10 @@ from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 import pytest
+import voluptuous as vol
 
 from custom_components.bmw_wallbox.config_flow import ConfigFlow, OptionsFlow
+from custom_components.bmw_wallbox.const import DOMAIN
 
 
 @pytest.fixture
@@ -206,3 +208,98 @@ async def test_options_flow_updates_values(hass: HomeAssistant) -> None:
     assert result["data"]["rfid_token"] == "NEWTOKEN456"
     assert result["data"]["max_current"] == 16
     assert result["data"]["scan_interval"] == 10
+
+
+async def test_options_flow_max_current_defaults_from_wallbox(
+    hass: HomeAssistant,
+) -> None:
+    """The 'Maximum Current (A)' field defaults to the wallbox-reported max."""
+    entry = MagicMock(spec_set=["data", "options", "entry_id"])
+    entry.entry_id = "test_entry"
+    entry.data = {
+        "charge_point_id": "DE*BMW*TEST123",
+        "rfid_token": "",
+        "max_current": 16,
+        "scan_interval": 30,
+    }
+    entry.options = {}
+
+    coordinator = MagicMock()
+    coordinator.data = {"max_current_a": 25}
+    hass.data[DOMAIN] = {"test_entry": coordinator}
+
+    flow = OptionsFlow()
+    _attach_config_entry(flow, entry)
+    flow.hass = hass
+
+    result = await flow.async_step_init()
+
+    schema = result["data_schema"]
+    max_current_default = next(
+        key.default() for key in schema.schema if str(key) == "max_current"
+    )
+    # Wallbox-reported 25 wins over the stored setup value of 16.
+    assert max_current_default == 25
+
+
+async def test_options_flow_saved_max_current_wins_over_wallbox(
+    hass: HomeAssistant,
+) -> None:
+    """A previously saved option takes precedence over the wallbox value."""
+    entry = MagicMock(spec_set=["data", "options", "entry_id"])
+    entry.entry_id = "test_entry"
+    entry.data = {
+        "charge_point_id": "DE*BMW*TEST123",
+        "rfid_token": "",
+        "max_current": 16,
+        "scan_interval": 30,
+    }
+    entry.options = {"max_current": 20}
+
+    coordinator = MagicMock()
+    coordinator.data = {"max_current_a": 25}
+    hass.data[DOMAIN] = {"test_entry": coordinator}
+
+    flow = OptionsFlow()
+    _attach_config_entry(flow, entry)
+    flow.hass = hass
+
+    result = await flow.async_step_init()
+
+    schema = result["data_schema"]
+    max_current_default = next(
+        key.default() for key in schema.schema if str(key) == "max_current"
+    )
+    # Saved option 20 wins over the wallbox-reported 25.
+    assert max_current_default == 20
+
+
+async def test_options_flow_max_current_capped_at_wallbox(
+    hass: HomeAssistant,
+) -> None:
+    """The 'Maximum Current (A)' field rejects values above the wallbox max."""
+    entry = MagicMock(spec_set=["data", "options", "entry_id"])
+    entry.entry_id = "test_entry"
+    entry.data = {
+        "charge_point_id": "DE*BMW*TEST123",
+        "rfid_token": "",
+        "max_current": 16,
+        "scan_interval": 30,
+    }
+    entry.options = {}
+
+    coordinator = MagicMock()
+    coordinator.data = {"max_current_a": 25}
+    hass.data[DOMAIN] = {"test_entry": coordinator}
+
+    flow = OptionsFlow()
+    _attach_config_entry(flow, entry)
+    flow.hass = hass
+
+    result = await flow.async_step_init()
+    schema = result["data_schema"]
+
+    # 25 (the reported max) is accepted; 26 is above the hardware ceiling.
+    assert schema({"rfid_token": "", "max_current": 25, "scan_interval": 30})
+    with pytest.raises(vol.Invalid):
+        schema({"rfid_token": "", "max_current": 26, "scan_interval": 30})

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -501,32 +501,16 @@ async def test_async_pause_charging_nuke_on_rejection(coordinator):
     """Test pause triggers NUKE (reboot) when SetChargingProfile is rejected."""
     mock_charge_point = MagicMock()
 
-    # First call: TriggerMessage (meter refresh before pause check)
-    # Second call: GetTransactionStatus (refresh)
-    # Third call: ClearChargingProfile
-    # Fourth call: SetChargingProfile (rejected)
-    # Fifth call: Reset (NUKE)
-    call_count = 0
-
     async def mock_call(request):
-        nonlocal call_count
-        call_count += 1
-
-        if call_count <= 3:
-            # TriggerMessage, GetTransactionStatus, and ClearChargingProfile
-            mock_resp = MagicMock()
-            mock_resp.ongoing_indicator = True
-            mock_resp.status = "Accepted"
-            return mock_resp
-        if call_count == 4:
-            # SetChargingProfile - REJECTED!
-            mock_resp = MagicMock()
+        # The 0 A pause SetChargingProfile is rejected; everything else (the
+        # Reset nuke) is accepted. Keyed by message type so it is resilient to
+        # the exact call sequence.
+        mock_resp = MagicMock()
+        if type(request).__name__ == "SetChargingProfile":
             mock_resp.status = "Rejected"
             mock_resp.status_info = None
-            return mock_resp
-        # Reset - accepted
-        mock_resp = MagicMock()
-        mock_resp.status = "Accepted"
+        else:
+            mock_resp.status = "Accepted"
         return mock_resp
 
     mock_charge_point.call = mock_call
@@ -545,22 +529,17 @@ async def test_async_pause_charging_no_nuke_when_disabled(coordinator):
     """Test pause does NOT trigger NUKE when allow_nuke=False."""
     mock_charge_point = MagicMock()
 
-    call_count = 0
+    reset_calls = []
 
     async def mock_call(request):
-        nonlocal call_count
-        call_count += 1
-
-        if call_count <= 3:
-            # TriggerMessage, GetTransactionStatus, ClearChargingProfile
-            mock_resp = MagicMock()
-            mock_resp.ongoing_indicator = True
-            mock_resp.status = "Accepted"
-            return mock_resp
-        # SetChargingProfile - REJECTED!
+        if type(request).__name__ == "Reset":
+            reset_calls.append(request)
         mock_resp = MagicMock()
-        mock_resp.status = "Rejected"
-        mock_resp.status_info = None
+        if type(request).__name__ == "SetChargingProfile":
+            mock_resp.status = "Rejected"
+            mock_resp.status_info = None
+        else:
+            mock_resp.status = "Accepted"
         return mock_resp
 
     mock_charge_point.call = mock_call
@@ -572,30 +551,18 @@ async def test_async_pause_charging_no_nuke_when_disabled(coordinator):
 
     assert result["success"] is False
     assert "rejected" in result["message"].lower()
-    # Should NOT have called Reset (only 4 calls: trigger + tx_status + clear + set)
-    assert call_count == 4
+    # Must NOT reboot when allow_nuke=False.
+    assert reset_calls == []
 
 
 async def test_async_pause_charging_nuke_on_timeout(coordinator):
     """Test pause triggers NUKE when command times out."""
     mock_charge_point = MagicMock()
 
-    call_count = 0
-
     async def mock_call(request):
-        nonlocal call_count
-        call_count += 1
-
-        if call_count <= 3:
-            # TriggerMessage, GetTransactionStatus, ClearChargingProfile
-            mock_resp = MagicMock()
-            mock_resp.ongoing_indicator = True
-            mock_resp.status = "Accepted"
-            return mock_resp
-        if call_count == 4:
-            # SetChargingProfile - TIMEOUT!
+        if type(request).__name__ == "SetChargingProfile":
+            # The 0 A pause SetChargingProfile times out.
             raise TimeoutError("Connection timed out")
-        # Reset - accepted
         mock_resp = MagicMock()
         mock_resp.status = "Accepted"
         return mock_resp
@@ -932,13 +899,13 @@ def _profile_purposes(mock_call):
     ]
 
 
-async def test_set_current_limit_clears_profiles_first_with_transaction(coordinator):
-    """Mid-session limit changes must clear existing profiles first (issue #14).
+async def test_set_current_limit_sends_only_txdefault_no_clear_no_refresh(coordinator):
+    """A limit change sends ONE TxDefaultProfile - never a TxProfile (issue #25).
 
-    The Delta firmware does not replace a profile with the same id/stack - it
-    rejects the duplicate. After a start/resume installed TxProfile id=999,
-    every slider change was Rejected until profiles were cleared first (the
-    pause/resume paths already do this and are accepted).
+    A transaction-bound TxProfile gets stuck to a faulted transaction on the
+    Delta firmware and orphans mid-session control (ClearChargingProfile returns
+    "Unknown", a duplicate is Rejected). We install only a TxDefaultProfile, so
+    there is no GetTransactionStatus refresh and no ClearChargingProfile first.
     """
     mock_cp = MagicMock()
     mock_response = MagicMock()
@@ -950,15 +917,11 @@ async def test_set_current_limit_clears_profiles_first_with_transaction(coordina
     assert await coordinator.async_set_current_limit(13.0) is True
 
     sent = [type(c.args[0]).__name__ for c in mock_cp.call.call_args_list]
-    # The sequence now re-reads the transaction id first: a TxProfile is bound to
-    # a transaction, and a stale id makes the box reject the only profile that
-    # can limit the session in progress.
-    assert sent[0] == "GetTransactionStatus"
-    assert sent[1] == "ClearChargingProfile"
-    # TxProfile (immediate) before TxDefaultProfile (next-session persistence)
-    purposes = _profile_purposes(mock_cp.call)
-    assert purposes == [
-        ChargingProfilePurposeEnumType.tx_profile,
+    assert "GetTransactionStatus" not in sent
+    assert "ClearChargingProfile" not in sent
+    assert sent == ["SetChargingProfile"]
+    # A single TxDefaultProfile, never a transaction-bound TxProfile.
+    assert _profile_purposes(mock_cp.call) == [
         ChargingProfilePurposeEnumType.tx_default_profile,
     ]
 
@@ -1002,10 +965,8 @@ async def test_set_current_limit_survives_cancellation(coordinator):
             await asyncio.sleep(0)
 
     sent = [type(c.args[0]).__name__ for c in mock_cp.call.call_args_list]
-    assert sent[0] == "GetTransactionStatus"
-    assert sent[1] == "ClearChargingProfile"
+    assert sent == ["SetChargingProfile"]
     assert _profile_purposes(mock_cp.call) == [
-        ChargingProfilePurposeEnumType.tx_profile,
         ChargingProfilePurposeEnumType.tx_default_profile,
     ]
 
@@ -1047,21 +1008,12 @@ async def test_set_current_limit_sequences_do_not_interleave(coordinator):
 
     # Old sequence ran to completion first, then the new one - no interleaving.
     sent = [type(c.args[0]).__name__ for c in mock_cp.call.call_args_list]
-    assert sent == [
-        "GetTransactionStatus",
-        "ClearChargingProfile",
-        "SetChargingProfile",
-        "SetChargingProfile",
-        "GetTransactionStatus",
-        "ClearChargingProfile",
-        "SetChargingProfile",
-        "SetChargingProfile",
-    ]
+    assert sent == ["SetChargingProfile", "SetChargingProfile"]
     limits = [
         msg.charging_profile.charging_schedule[0].charging_schedule_period[0].limit
         for msg in _set_profile_messages(mock_cp.call)
     ]
-    assert limits == [15.0, 15.0, 19.0, 19.0]
+    assert limits == [15.0, 19.0]
     assert coordinator.data["current_limit"] == 19.0
 
 
@@ -1081,12 +1033,10 @@ async def test_set_current_limit_no_clear_without_transaction(coordinator):
 
 
 async def test_set_current_limit_profiles_use_stack_level_zero(coordinator):
-    """Every profile the slider sends must use stack_level=0 (issue #14 retest).
+    """The single TxDefaultProfile the slider sends uses stack_level=0.
 
     Delta firmware with ChargingProfileMaxStackLevel=0 rejects any profile at a
-    higher stack level, so a TxProfile at stack 1 was accepted-by-tests but
-    Rejected by the real wallbox and the limit never applied mid-session.
-    TxProfile already outranks TxDefaultProfile by purpose alone.
+    higher stack level.
     """
     mock_cp = MagicMock()
     mock_response = MagicMock()
@@ -1100,11 +1050,11 @@ async def test_set_current_limit_profiles_use_stack_level_zero(coordinator):
     stack_levels = [
         msg.charging_profile.stack_level for msg in _set_profile_messages(mock_cp.call)
     ]
-    assert stack_levels == [0, 0]
+    assert stack_levels == [0]
 
 
 async def test_set_current_limit_sends_tx_default_profile(coordinator):
-    """During a session both TxDefaultProfile and TxProfile are sent (issue #15)."""
+    """During a session ONLY a TxDefaultProfile is sent - never a TxProfile."""
     mock_cp = MagicMock()
     mock_response = MagicMock()
     mock_response.status = "Accepted"
@@ -1116,8 +1066,8 @@ async def test_set_current_limit_sends_tx_default_profile(coordinator):
 
     assert result is True
     purposes = _profile_purposes(mock_cp.call)
-    assert ChargingProfilePurposeEnumType.tx_default_profile in purposes
-    assert ChargingProfilePurposeEnumType.tx_profile in purposes
+    assert purposes == [ChargingProfilePurposeEnumType.tx_default_profile]
+    assert ChargingProfilePurposeEnumType.tx_profile not in purposes
     assert coordinator.data["current_limit"] == 13.0
 
 
@@ -1183,16 +1133,15 @@ async def test_resume_reinstalls_tx_default_profile(coordinator):
         result = await coordinator.async_resume_charging()
 
     assert result["success"] is True
+    # Resume installs ONLY a TxDefaultProfile - never a transaction-bound
+    # TxProfile that could get stuck and orphan the session (issue #25).
     purposes = _profile_purposes(mock_cp.call)
-    assert purposes == [
-        ChargingProfilePurposeEnumType.tx_profile,
-        ChargingProfilePurposeEnumType.tx_default_profile,
-    ]
+    assert purposes == [ChargingProfilePurposeEnumType.tx_default_profile]
     limits = [
         msg.charging_profile.charging_schedule[0].charging_schedule_period[0].limit
         for msg in _set_profile_messages(mock_cp.call)
     ]
-    assert limits == [6.0, 6.0]
+    assert limits == [6.0]
 
 
 async def test_apply_limit_on_charging_resumed(coordinator):
@@ -1419,38 +1368,43 @@ def _profile_response(accepted_purposes):
     return call
 
 
-async def test_limit_fails_when_tx_profile_rejected_during_session(coordinator):
-    """Session live + TxProfile rejected => failure, even if default accepted."""
+async def test_limit_fails_when_txdefault_rejected(coordinator):
+    """TxDefaultProfile rejected => failure; the entity must not claim success."""
     mock_cp = MagicMock()
     mock_cp.call = AsyncMock(
-        side_effect=_profile_response(
-            {ChargingProfilePurposeEnumType.tx_default_profile}
-        )
+        side_effect=_profile_response(set())  # reject everything
     )
     coordinator.charge_point = mock_cp
     coordinator.current_transaction_id = "tx-123"
-    coordinator.async_refresh_transaction_id = AsyncMock()
 
     assert await coordinator.async_set_current_limit(6.0) is False
     # The entity must NOT claim the car is limited when it is not.
     assert coordinator.data.get("current_limit") != 6.0
 
 
-async def test_limit_succeeds_when_tx_profile_accepted_and_default_rejected(
-    coordinator,
-):
-    """The original issue #14 case still passes: only the TxProfile matters."""
+async def test_limit_never_sends_tx_profile_during_session(coordinator):
+    """Regression guard: a live session must never install a TxProfile.
+
+    A transaction-bound TxProfile is what got stuck to a faulted transaction and
+    orphaned mid-session control on the Delta firmware (issue #25).
+    """
     mock_cp = MagicMock()
-    mock_cp.call = AsyncMock(
-        side_effect=_profile_response({ChargingProfilePurposeEnumType.tx_profile})
-    )
+    mock_response = MagicMock()
+    mock_response.status = "Accepted"
+    mock_cp.call = AsyncMock(return_value=mock_response)
     coordinator.charge_point = mock_cp
     coordinator.current_transaction_id = "tx-123"
-    coordinator.async_refresh_transaction_id = AsyncMock()
-    coordinator.async_set_updated_data = MagicMock()
 
     assert await coordinator.async_set_current_limit(6.0) is True
     assert coordinator.data["current_limit"] == 6.0
+    assert ChargingProfilePurposeEnumType.tx_profile not in _profile_purposes(
+        mock_cp.call
+    )
+    # And no profile carries a transactionId.
+    assert all(
+        getattr(msg.charging_profile, "transaction_id", None) is None
+        for msg in _set_profile_messages(mock_cp.call)
+    )
 
 
 async def test_limit_succeeds_with_default_only_when_no_session(coordinator):
@@ -1463,24 +1417,97 @@ async def test_limit_succeeds_with_default_only_when_no_session(coordinator):
     )
     coordinator.charge_point = mock_cp
     coordinator.current_transaction_id = None
-    coordinator.async_refresh_transaction_id = AsyncMock()
     coordinator.async_set_updated_data = MagicMock()
 
     assert await coordinator.async_set_current_limit(16.0) is True
     assert coordinator.data["current_limit"] == 16.0
 
 
-async def test_limit_sequence_refreshes_transaction_id_first(coordinator):
-    """A stale transaction id is what made the box reject the TxProfile."""
+# ==============================================================================
+# ISSUE #25 - diagnostics: enforced-limit sensor, ReportChargingProfiles, faults
+# ==============================================================================
+
+
+async def test_report_charging_profiles_flags_stuck_txprofile(charge_point):
+    """A reported transaction-bound TxProfile must raise the stuck flag."""
+    await charge_point.on_report_charging_profiles(
+        request_id=1,
+        charging_limit_source="CSO",
+        charging_profile=[
+            {"id": 999, "chargingProfilePurpose": "TxProfile"},
+        ],
+        evse_id=1,
+    )
+    assert charge_point.coordinator.data["stuck_tx_profile"] is True
+    assert len(charge_point.coordinator.data["installed_profiles"]) == 1
+
+
+async def test_report_charging_profiles_no_stuck_for_txdefault(charge_point):
+    """A TxDefaultProfile is not transaction-bound - never flags stuck."""
+    await charge_point.on_report_charging_profiles(
+        request_id=1,
+        charging_limit_source="CSO",
+        charging_profile=[
+            {"id": 998, "chargingProfilePurpose": "TxDefaultProfile"},
+        ],
+        evse_id=1,
+    )
+    assert charge_point.coordinator.data["stuck_tx_profile"] is False
+
+
+async def test_status_notification_faulted_sets_fault(charge_point):
+    """A connector 'Faulted' surfaces as a fault state (issue #25)."""
+    await charge_point.on_status_notification(
+        timestamp=datetime.utcnow().isoformat(),
+        connector_status="Faulted",
+        evse_id=1,
+        connector_id=1,
+    )
+    assert charge_point.coordinator.data["wallbox_fault"] is True
+    assert charge_point.coordinator.data["last_fault"] == "Connector Faulted"
+    assert charge_point.coordinator.data.get("last_fault_time")
+
+    # And it clears when the connector goes back to a healthy state.
+    await charge_point.on_status_notification(
+        timestamp=datetime.utcnow().isoformat(),
+        connector_status="Occupied",
+        evse_id=1,
+        connector_id=1,
+    )
+    assert charge_point.coordinator.data["wallbox_fault"] is False
+
+
+async def test_get_composite_schedule_stores_enforced_limit(coordinator):
+    """GetCompositeSchedule's first-period limit lands in enforced_limit_a."""
     mock_cp = MagicMock()
-    mock_response = MagicMock()
-    mock_response.status = "Accepted"
-    mock_response.status_info = None
-    mock_cp.call = AsyncMock(return_value=mock_response)
+    response = MagicMock()
+    response.schedule = {"charging_schedule_period": [{"limit": 10.0}]}
+    mock_cp.call = AsyncMock(return_value=response)
     coordinator.charge_point = mock_cp
-    coordinator.current_transaction_id = "stale-tx"
-    coordinator.async_refresh_transaction_id = AsyncMock()
 
-    await coordinator.async_set_current_limit(16.0)
+    assert await coordinator.async_get_composite_schedule() == 10.0
+    assert coordinator.data["enforced_limit_a"] == 10.0
 
-    coordinator.async_refresh_transaction_id.assert_awaited_once()
+
+async def test_get_variable_reads_device_model_value(coordinator):
+    """async_get_variable returns the wallbox's configured value (feature #5)."""
+    mock_cp = MagicMock()
+    response = MagicMock()
+    response.get_variable_result = [
+        {"attribute_status": "Accepted", "attribute_value": "32"}
+    ]
+    mock_cp.call = AsyncMock(return_value=response)
+    coordinator.charge_point = mock_cp
+
+    assert await coordinator.async_get_variable("ChargingStation", "MaxCurrent") == "32"
+
+
+async def test_get_variable_returns_none_when_rejected(coordinator):
+    """A rejected GetVariables read yields None, not a bogus value."""
+    mock_cp = MagicMock()
+    response = MagicMock()
+    response.get_variable_result = [{"attribute_status": "Rejected"}]
+    mock_cp.call = AsyncMock(return_value=response)
+    coordinator.charge_point = mock_cp
+
+    assert await coordinator.async_get_variable("ChargingStation", "Nope") is None

--- a/tests/test_delta_gen4_simulation.py
+++ b/tests/test_delta_gen4_simulation.py
@@ -100,7 +100,7 @@ class DeltaGen4Simulator:
 
     def _respond_set_profile(self, payload: dict) -> dict:
         profile = payload["chargingProfile"]
-        # Issue #14: one rejection poisons the whole transaction
+        # Issue #14: one TxProfile rejection poisons the whole transaction
         if self.poisoned:
             return {"status": "Rejected", "statusInfo": {"reasonCode": "TxPoisoned"}}
         # Issue #14: ChargingProfileMaxStackLevel=0
@@ -109,19 +109,26 @@ class DeltaGen4Simulator:
                 "status": "Rejected",
                 "statusInfo": {"reasonCode": "StackLevelOutOfRange"},
             }
-        # Issue #14: same-id profiles are not replaced - the duplicate is
-        # rejected and the transaction is poisoned from here on
-        if profile["id"] in self.stored_profile_ids:
-            self.poisoned = True
-            return {"status": "Rejected", "statusInfo": {"reasonCode": "DuplicateId"}}
 
         limit = profile["chargingSchedule"][0]["chargingSchedulePeriod"][0]["limit"]
         purpose = profile["chargingProfilePurpose"]
         if purpose == "TxDefaultProfile":
-            # Persistent config - stored regardless of charging state
+            # A TxDefaultProfile is replaced in place: the Delta accepts the same
+            # id again and updates the stored limit - no duplicate rejection, no
+            # poison (measured live 2026-08-29, 32A->10A->6A all Accepted). This
+            # is why the integration installs ONLY TxDefaultProfiles (issue #25).
             self.stored_default_limit = limit
             self.stored_profile_ids.add(profile["id"])
-        elif self.charging_state == "Charging":
+            return {"status": "Accepted"}
+
+        # Issue #14: a transaction-bound TxProfile with a duplicate id is NOT
+        # replaced - the duplicate is rejected and the transaction poisoned from
+        # here on. The integration no longer sends TxProfiles, so this is a
+        # regression guard: if any path regresses to a TxProfile it will trip.
+        if profile["id"] in self.stored_profile_ids:
+            self.poisoned = True
+            return {"status": "Rejected", "statusInfo": {"reasonCode": "DuplicateId"}}
+        if self.charging_state == "Charging":
             self.applied_tx_limit = limit
             self.stored_profile_ids.add(profile["id"])
         # else: the issue #19 quirk - "Accepted", then silently discarded
@@ -252,10 +259,10 @@ async def test_issue19_resume_keeps_configured_limit(sim_setup):
     # 1. Active session, charging
     await _start_session(sim, coordinator)
 
-    # 2. User limits the current to 6A - both profiles land on the wallbox
+    # 2. User limits the current to 6A - the TxDefaultProfile lands (no TxProfile)
     assert await coordinator.async_set_current_limit(6.0) is True
-    assert sim.applied_tx_limit == 6.0
     assert sim.stored_default_limit == 6.0
+    assert sim.drawn_current() == 6.0
 
     # 3. The EV suspends the session
     await sim.send_transaction_event("Updated", "SuspendedEVSE", seq_no=2)
@@ -266,17 +273,13 @@ async def test_issue19_resume_keeps_configured_limit(sim_setup):
     assert result["success"] is True
     assert result["action"] == "resumed"
 
-    # Fix layer 1: the TxDefaultProfile safety net survives the resume's
-    # clear-all, even though the firmware discarded the suspended TxProfile.
-    assert sim.applied_tx_limit is None  # quirk: accepted but discarded
+    # The TxDefaultProfile is not transaction-bound, so it is never discarded
+    # or poisoned: the configured limit holds across the whole cycle.
     assert sim.stored_default_limit == 6.0
 
     # 5. The wallbox actually resumes charging
     await sim.send_transaction_event("Updated", "Charging", seq_no=3)
-
-    # Fix layer 2: the Suspended->Charging transition re-pushes the limit,
-    # now in a state where the firmware honours the TxProfile.
-    await _wait_for(lambda: sim.applied_tx_limit == 6.0)
+    await _wait_for(lambda: coordinator.data.get("charging_state") == "Charging")
 
     # The issue #19 assertion: 6A, not the unrestricted hardware maximum.
     assert sim.drawn_current() == 6.0
@@ -325,7 +328,7 @@ async def test_issue14_notify_ev_charging_needs_answered_cleanly(sim_setup):
     # And the OCPP channel is still healthy: a limit change right after the
     # ISO 15118 negotiation must land normally.
     assert await coordinator.async_set_current_limit(10.0) is True
-    assert sim.applied_tx_limit == 10.0
+    assert sim.stored_default_limit == 10.0
 
 
 async def test_issue14_consecutive_limit_changes_never_poison(sim_setup):
@@ -343,13 +346,13 @@ async def test_issue14_consecutive_limit_changes_never_poison(sim_setup):
         assert await coordinator.async_set_current_limit(amps) is True, (
             f"limit change to {amps}A was rejected"
         )
-        assert sim.applied_tx_limit == amps
+        assert sim.stored_default_limit == amps
         assert sim.poisoned is False
 
     # Interleave the ISO 15118 message like the real Gen 4 does, then keep going
     await sim.send_notify_ev_charging_needs()
     assert await coordinator.async_set_current_limit(8.0) is True
-    assert sim.applied_tx_limit == 8.0
+    assert sim.stored_default_limit == 8.0
     assert sim.call_errors == []
 
 
@@ -385,7 +388,8 @@ async def test_issue14_pause_resume_cycle_survives_duplicate_quirk(sim_setup):
     assert result["action"] == "resumed"
 
     await sim.send_transaction_event("Updated", "Charging", seq_no=3)
-    await _wait_for(lambda: sim.applied_tx_limit == 6.0)
+    # Resume re-applies the tracked limit as a TxDefaultProfile.
+    await _wait_for(lambda: sim.stored_default_limit == 6.0)
     assert sim.drawn_current() == 6.0
     assert sim.poisoned is False
 


### PR DESCRIPTION
## Summary

**v2.0.0 — major release.** Fixes the recurring "I raise the wallbox limit and the watts don't change; only a reboot fixes it" bug at the root, and adds OCPP diagnostic/config entities. This is a **breaking** change: the charging-control strategy switched from `TxProfile` to `TxDefaultProfile` only, and the public `async_refresh_transaction_id` method was removed.

### The bug (root-caused live)

Captured raw OCPP frames on the real Delta Gen 4 (firmware `01.20.06.71`): the integration installed a transaction-bound `TxProfile` (id 999). After a mid-session `SuspendedEVSE`/connector-`Faulted` event the Delta **refuses to clear or replace it** — `ClearChargingProfile` returns `Unknown` (by id and by criteria), and a duplicate `SetChargingProfile` returns `Rejected`. The transaction "orphans" and every later limit change is silently rejected until a reboot forces a new transaction.

### The fix

Install **only a `TxDefaultProfile`** (no `transactionId`) across every path — limit changes, session start, pause (0 A), resume — so nothing can pin itself to a faulted transaction. Measured live: `TxDefaultProfile` is replaced in place (32→10→6 A all `Accepted`) and drives the composite schedule, so mid-session control works without a reboot. This is the EVCC approach.

## Added

- `sensor.enforced_current_limit` — the limit the wallbox is *actually* enforcing (`GetCompositeSchedule`), so a rejected/ignored limit is visible instead of silent.
- `binary_sensor.fault` — connector `Faulted` / NotifyEvent alerts as a first-class state, with reason/timestamp attributes and a `stuck_tx_profile` flag. Entity only — no push notifications.
- `ReportChargingProfiles` handler — previously threw `NotImplementedError`; now parsed for diagnostics and warns on a stuck `TxProfile`.
- `sensor.max_charging_current` — the hardware max current (`GetVariables`). The **"Maximum Current (A)" option is now bounded by and defaults to this value**, so you can only pick a limit between 6 A and the real hardware maximum.
- `number.led_brightness` — read/write LED brightness (`GetVariables`/`SetVariables`); also corrects the wrong device-model path (`StatusLED.brightness`).

## Removed (breaking)

- The `TxProfile`/refresh/clear machinery and the public `async_refresh_transaction_id` method — the source of the stuck profile.

## Test plan

- [x] `ruff check` + `ruff format` clean
- [x] `pytest` — 147 passed (rewritten for the TxDefault-only contract, regression guard that no `TxProfile` is ever sent, new config-flow ceiling tests)
- [x] Live on the real Delta Gen 4: fresh-session raise 6→23.9 A and lower to 8 A both apply without reboot; only `TxDefaultProfile` frames on the wire
- [x] Live: all 5 new entities populate with real data (`enforced` = 25, `fault` = off, LED read 30 / write 70, `max` = 25)
